### PR TITLE
app macOS na release + link do server no app

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,19 @@ A ideia nasceu de um Galaxy J5 velho parado em casa. A vontade era fazer algo ú
 ### Mac app (recomendado)
 
 ```sh
-# Pré-requisitos: macOS 14+ (Liquid Glass completo no 26+), Xcode CLT (Swift), Node.js 20+ (o app usa o `node` do sistema)
+# Baixe o Dokke-macOS.zip na página de release → descompacte → abra o Dokke.app
+# (Node.js já embutido — nada pra instalar)
+```
+
+Ou build do source (requer macOS 14+, Xcode CLT e Node.js 20+):
+
+```sh
 git clone https://github.com/felipenalves/Dokke.git
 cd Dokke
 cd mac && ./install.sh --open
 ```
 
-> **Node.js**: instale via `brew install node` ou do [nodejs.org](https://nodejs.org). Se você não tiver Node, use a opção **Terminal** abaixo só depois de instalar — ou use o **Android** (que não precisa de nada instalado no PC além do server rodando).
-
-O app inicia o server automaticamente. Fechar o app mata o server.
+O app inicia o server automaticamente (aba **Sobre** mostra o link de acesso pra usar de outros devices). Fechar o app mata o server.
 
 ### Terminal
 

--- a/mac/Sources/ContentView.swift
+++ b/mac/Sources/ContentView.swift
@@ -96,6 +96,41 @@ struct AboutView: View {
       )
 
       VStack(alignment: .leading, spacing: 10) {
+        Text("Conectar outros dispositivos")
+          .font(.headline)
+        if let ip = ServerManager.lanIPv4() {
+          HStack(spacing: 8) {
+            Text("http://\(ip):3000")
+              .font(.system(size: 15, weight: .semibold, design: .monospaced))
+              .textSelection(.enabled)
+            Button {
+              NSPasteboard.general.clearContents()
+              NSPasteboard.general.setString("http://\(ip):3000", forType: .string)
+            } label: {
+              Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("Copiar link")
+          }
+        } else {
+          Text("Sem IP de rede detectado (offline?)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        Text("Abra este link no Android, iPad ou qualquer navegador para usar o dock sem instalar nada.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Text("iPhone/iPad PWA: o iOS exige HTTPS — rode `cloudflared tunnel --url http://localhost:3000` e salve a URL no Safari.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+      .background(
+        RoundedRectangle(cornerRadius: 12)
+          .fill(.quaternary)
+      )
+
+      VStack(alignment: .leading, spacing: 10) {
         HStack {
           Text("Código de acesso")
             .font(.headline)

--- a/mac/Sources/ServerManager.swift
+++ b/mac/Sources/ServerManager.swift
@@ -44,10 +44,16 @@ final class ServerManager: ObservableObject {
     return nil
   }
 
-  /// Localiza o binário do node — override, depois os caminhos comuns.
+  /// Localiza o binário do node — node embutido no bundle (Contents/Resources/node-bin),
+  /// depois override e caminhos comuns.
   static func locateNode() -> String? {
     let fm = FileManager.default
-    let candidates = [
+    let bundledNode = Bundle.main.resourceURL?
+      .appendingPathComponent("node-bin", isDirectory: true)
+      .appendingPathComponent("node", isDirectory: false)
+      .path
+    let candidates: [String?] = [
+      bundledNode,
       ProcessInfo.processInfo.environment["DOKKE_NODE"],
       UserDefaults.standard.string(forKey: "dokke.nodePath"),
       "/opt/homebrew/bin/node",
@@ -59,6 +65,34 @@ final class ServerManager: ObservableObject {
       return c
     }
     return nil
+  }
+
+  /// IP IPv4 da LAN (en0/en1) — mostrado na aba Sobre como link de acesso dos devices.
+  static func lanIPv4() -> String? {
+    var addr: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&ifaddr) == 0 else { return nil }
+    defer { freeifaddrs(ifaddr) }
+    var ptr = ifaddr
+    while ptr != nil {
+      let interface = ptr!.pointee
+      let family = interface.ifa_addr.pointee.sa_family
+      if family == UInt8(AF_INET) {
+        let name = String(cString: interface.ifa_name)
+        if name.hasPrefix("en") && !name.contains("awdl") {
+          var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+          getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
+                      &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST)
+          let h = String(cString: host)
+          if !h.hasPrefix("169.254") {
+            addr = h
+            break
+          }
+        }
+      }
+      ptr = interface.ifa_next
+    }
+    return addr
   }
 
   func start() {

--- a/mac/install.sh
+++ b/mac/install.sh
@@ -67,6 +67,18 @@ else
   echo "warn: npm/node_modules ausentes — server pode não subir (dependência ws ausente)"
 fi
 
+# embute o node no bundle (Contents/Resources/node-bin) — o app roda em Mac
+# sem Node instalado; o ServerManager.locateNode olha o bundle primeiro.
+NODE_SRC="$(command -v node || true)"
+if [[ -n "${NODE_SRC}" ]]; then
+  mkdir -p "${APP_BUNDLE}/Contents/Resources/node-bin"
+  cp -L "${NODE_SRC}" "${APP_BUNDLE}/Contents/Resources/node-bin/node"
+  chmod +x "${APP_BUNDLE}/Contents/Resources/node-bin/node"
+  echo "==> node embutido ($(du -sh "${APP_BUNDLE}/Contents/Resources/node-bin/node" | cut -f1))"
+else
+  echo "warn: node não encontrado no sistema — o app usará o node do Mac (se existir)"
+fi
+
 if command -v codesign >/dev/null 2>&1; then
   codesign --force --deep --sign - "${APP_BUNDLE}" 2>/dev/null || true
 fi


### PR DESCRIPTION
- **Dokke-macOS.zip** na release: app pronto, Node embutido — descompacta e abre, zero instalação\n- Aba Sobre mostra o link `http://IP:3000` (IP detectado) + dica do túnel HTTPS pro iPhone\n- README quick start simplificado