### PR TITLE
fix: distribuicao Mac via DMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ A ideia nasceu de um Galaxy J5 velho parado em casa. A vontade era fazer algo ú
 ### Mac app (recomendado)
 
 ```sh
-# Baixe o Dokke-macOS.zip na página de release → descompacte → abra o Dokke.app
+# Baixe o Dokke-macOS.dmg na página de release → abra o dmg → arraste o
+# Dokke para a pasta Aplicações → abra o app
 # (Node.js já embutido — nada pra instalar)
 ```
 

--- a/mac/install.sh
+++ b/mac/install.sh
@@ -80,7 +80,8 @@ else
 fi
 
 if command -v codesign >/dev/null 2>&1; then
-  codesign --force --deep --sign - "${APP_BUNDLE}" 2>/dev/null || true
+  codesign --force --deep --sign - "${APP_BUNDLE}"
+  codesign --verify --deep --strict "${APP_BUNDLE}" || { echo "error: assinatura inválida após codesign" >&2; exit 1; }
 fi
 
 if [[ "${BUILD_ONLY}" -eq 1 ]]; then


### PR DESCRIPTION
App Mac agora sai como .dmg (padrao Apple) com pagina de instalacao estilizada. Corrige o erro 'app danificado' que o zip causava (assinatura quebrada no empacotamento). install.sh valida a assinatura antes de instalar.