### PR TITLE
docs: primeira abertura do app Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ A ideia nasceu de um Galaxy J5 velho parado em casa. A vontade era fazer algo ú
 # (Node.js já embutido — nada pra instalar)
 ```
 
+> **Primeira abertura:** se o macOS mostrar um aviso do tipo *"Dokke não pode ser aberto
+> porque vem de um desenvolvedor não identificado"*, é só: **clique com o botão direito
+> no Dokke.app → Abrir → confirme**. Na primeira vez o macOS pede essa confirmação;
+> depois disso o app abre normalmente.
+
 Ou build do source (requer macOS 14+, Xcode CLT e Node.js 20+):
 
 ```sh


### PR DESCRIPTION
Adiciona no README o passo a passo pra quando o macOS pedir confirmacao na primeira abertura (clique direito > Abrir).