### PR TITLE
fix: teclado recua ao concluir PIN no Android

### DIFF
--- a/android/app/src/main/java/com/dokke/app/MainActivity.kt
+++ b/android/app/src/main/java/com/dokke/app/MainActivity.kt
@@ -98,6 +98,16 @@ class MainActivity : ComponentActivity() {
             }
         }
         web.clearCache(true)
+        web.addJavascriptInterface(object {
+            @android.webkit.JavascriptInterface
+            fun hideKeyboard() {
+                runOnUiThread {
+                    web.clearFocus()
+                    (getSystemService(Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager)
+                        .hideSoftInputFromWindow(web.windowToken, 0)
+                }
+            }
+        }, "DokkeAndroid")
         web.loadUrl(url)
         // descoberta automática: se o IP do Mac mudou, atualiza sozinho
         discoverServer { found ->

--- a/public/index.html
+++ b/public/index.html
@@ -698,6 +698,10 @@
     const r = await post("/api/auth", { pin: val }).catch(function(){ return { status: 0, data: null }; });
     if (r && r.status === 200 && r.data && r.data.ok === true){
       authed = true;
+      // tira o foco do input pra o teclado recuar (mobile/WebView)
+      const active = document.activeElement;
+      if (active && active.blur) active.blur();
+      try { if (window.DokkeAndroid) window.DokkeAndroid.hideKeyboard(); } catch (e) {}
       hideLogin();
       boot();
     } else if (r && r.status === 429){


### PR DESCRIPTION
Ao digitar o PIN e tocar em Concluir, o teclado ficava aberto no Android ate clicar fora. Agora o input perde o foco no sucesso do login (funciona no PWA/browser tambem) e o WebView nativo esconde o teclado via bridge DokkeAndroid.hideKeyboard().