### PR TITLE
fix: checagem de versão sem GitHub API

### DIFF
--- a/android/app/src/main/java/com/dokke/app/MainActivity.kt
+++ b/android/app/src/main/java/com/dokke/app/MainActivity.kt
@@ -4,14 +4,12 @@ import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.Context
 import android.graphics.Color
-import android.net.http.SslError
 import android.os.Bundle
 import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.webkit.ConsoleMessage
 import android.webkit.JsResult
-import android.webkit.SslErrorHandler
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -49,8 +47,7 @@ class MainActivity : ComponentActivity() {
             systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             hide(WindowInsetsCompat.Type.systemBars())
         }
-        // permite debug remoto do WebView via chrome://inspect
-        WebView.setWebContentsDebuggingEnabled(true)
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
 
         web = WebView(this)
         loader = ProgressBar(this).apply { isIndeterminate = true }
@@ -76,7 +73,6 @@ class MainActivity : ComponentActivity() {
         web.setBackgroundColor(Color.BLACK)
         web.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, u: String?) { loader.visibility = View.GONE }
-            override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) { handler?.proceed() }
             override fun onReceivedError(view: WebView?, request: android.webkit.WebResourceRequest?, error: android.webkit.WebResourceError?) {
                 Log.e("Dokke", "WebView error: ${error?.description} (${error?.errorCode}) url=${request?.url}")
                 // self-heal: se o IP gravado morreu (DHCP mudou), procura o servidor na rede

--- a/mac/Sources/ContentView.swift
+++ b/mac/Sources/ContentView.swift
@@ -57,7 +57,24 @@ struct AboutView: View {
   @State private var updateChecking = false
   @State private var updateNote: String?
 
+  private func compareVersion(_ a: String, _ b: String) -> Int {
+    let pa = a.trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
+      .split(separator: ".")
+      .map { Int($0) ?? 0 }
+    let pb = b.trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
+      .split(separator: ".")
+      .map { Int($0) ?? 0 }
+    for i in 0..<3 {
+      let av = i < pa.count ? pa[i] : 0
+      let bv = i < pb.count ? pb[i] : 0
+      if av != bv { return av > bv ? 1 : -1 }
+    }
+    return 0
+  }
+
   private func checkUpdate() async {
+    update = nil
+    updateNote = nil
     updateChecking = true
     defer { updateChecking = false }
     do {
@@ -66,10 +83,10 @@ struct AboutView: View {
       let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
       let local = json?["local"] as? [String: Any]
       let latest = json?["latest"] as? [String: Any]
-      guard let lt = latest as? [String: Any],
+      guard let lt = latest,
             let tag = lt["tag"] as? String, !tag.isEmpty,
             let localTag = local?["tag"] as? String,
-            tag != localTag else {
+            compareVersion(tag, localTag) > 0 else {
         updateNote = "Você está na versão mais recente."
         return
       }

--- a/server.js
+++ b/server.js
@@ -40,28 +40,44 @@ const PIN_MAX_FAILS = 5;
 const PIN_LOCK_MS = 60_000;
 const pinLocks = new Map();
 
-// versão publicada no GitHub (releases/latest) — cacheia 10min; nunca bloqueia o request
-const versionCache = { value: null, age: 0 };
+// versão publicada no GitHub (releases/latest) — stale-while-revalidate; nunca bloqueia o request
+// usa redirect da URL pública (sem API → sem rate limit)
+const VERSION_CACHE_MS = 10 * 60 * 1000;
+const versionCache = { value: null, age: 0, refreshing: null };
 async function refreshVersion() {
-  try {
-    const ctrl = new AbortController();
-    const t = setTimeout(() => ctrl.abort(), 5000);
-    const r = await fetch("https://api.github.com/repos/felipenalves/Dokke/releases/latest",
-      { headers: { "User-Agent": "Dokke", "Accept": "application/vnd.github+json" }, signal: ctrl.signal });
-    clearTimeout(t);
-    if (!r.ok) return;
-    const j = await r.json();
-    const apk = (j.assets || []).find(a => /^dokke\.apk$/.test(a.name));
-    versionCache.value = {
-      tag: j.tag_name || "",
-      htmlUrl: j.html_url || "",
-      apkUrl: apk ? apk.browser_download_url : "",
-      published: j.published_at || "",
-    };
-    versionCache.age = Date.now();
-  } catch {}
+  if (versionCache.refreshing) return versionCache.refreshing;
+  versionCache.refreshing = (async () => {
+    let timer = null;
+    try {
+      const ctrl = new AbortController();
+      timer = setTimeout(() => ctrl.abort(), 5000);
+      const r = await fetch("https://github.com/felipenalves/Dokke/releases/latest",
+        { redirect: "manual", signal: ctrl.signal });
+      const loc = r.headers.get("location") || "";
+      const m = loc.match(/\/releases\/tag\/([^/]+)$/);
+      if (!m) return;
+      versionCache.value = {
+        tag: m[1],
+        htmlUrl: "https://github.com/felipenalves/Dokke/releases/tag/" + m[1],
+        apkUrl: "https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk",
+      };
+      versionCache.age = Date.now();
+    } catch {
+    } finally {
+      if (timer) clearTimeout(timer);
+      versionCache.refreshing = null;
+    }
+  })();
+  return versionCache.refreshing;
 }
 refreshVersion();
+
+function latestVersionSnapshot() {
+  if (!versionCache.age || Date.now() - versionCache.age >= VERSION_CACHE_MS) {
+    refreshVersion();
+  }
+  return versionCache.value;
+}
 
 const SEC_HEADERS = {
   "X-Content-Type-Options": "nosniff",
@@ -272,9 +288,7 @@ export function makeApp(deps = {}) {
         const raw = readFileSync(join(root, "version.json"), "utf8");
         local = JSON.parse(raw);
       } catch {}
-      const latest = versionCache.age && Date.now() - versionCache.age < 10 * 60 * 1000
-        ? versionCache.value : null;
-      ok({ ok: true, local, latest });
+      ok({ ok: true, local, latest: latestVersionSnapshot() });
       return;
     }
     // ---------- auth: pin de 4 dígitos (gate do kiosk da LAN) ----------


### PR DESCRIPTION
A GitHub API estoura rate limit (60/h por IP sem token) e o aviso de atualizacao morria. Agora usa o redirect da URL publica /releases/latest — sem API, sem limite.