### PR TITLE
feat(android): atualização do APK com consentimento do usuário

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -10,6 +10,8 @@ reescrito.
 - Aceita cert local (Tailscale) para não travar em HTTP/self-signed.
 - Botão voltar do Android navega para trás dentro do app.
 - Tela de "loading" enquanto carrega.
+- Aviso de nova versão quando existe uma release mais recente no GitHub.
+- Download iniciado somente após o toque do usuário; a instalação passa pelo instalador oficial do Android.
 - **Login por código**: o dock pede o pin de 4 dígitos (aba "Sobre" do app Dokke no Mac)
   na primeira conexão; o cookie dura 180 dias.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/com/dokke/app/MainActivity.kt
+++ b/android/app/src/main/java/com/dokke/app/MainActivity.kt
@@ -2,15 +2,22 @@ package com.dokke.app
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
+import android.net.Uri
 import android.os.Bundle
+import android.os.Build
+import android.os.Environment
+import android.provider.Settings
 import android.util.Log
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
 import android.webkit.ConsoleMessage
 import android.webkit.JsResult
 import android.webkit.WebChromeClient
@@ -23,6 +30,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -41,6 +49,41 @@ class MainActivity : ComponentActivity() {
     private var serverUrl = ""
     private var mainFrameFailed = false
     private var healed = false
+    private var updateDownloadId: Long? = null
+    private var pendingUpdateVersion: String? = null
+    private var updateReceiverRegistered = false
+
+    private val updateApkUrl = "https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk"
+    private val updateMime = "application/vnd.android.package-archive"
+    private val updateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L) ?: return
+            if (id <= 0 || id != updateDownloadId) return
+            updateDownloadId = null
+
+            val manager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            val cursor = manager.query(DownloadManager.Query().setFilterById(id))
+            try {
+                if (!cursor.moveToFirst()) {
+                    showUpdateMessage("Não foi possível verificar o download.")
+                    return
+                }
+                val status = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+                if (status != DownloadManager.STATUS_SUCCESSFUL) {
+                    showUpdateMessage("Não foi possível baixar a atualização.")
+                    return
+                }
+                val uri = manager.getUriForDownloadedFile(id)
+                if (uri == null) {
+                    showUpdateMessage("O arquivo da atualização não está disponível.")
+                    return
+                }
+                installDownloadedApk(uri)
+            } finally {
+                cursor.close()
+            }
+        }
+    }
 
     private val discoverMagic = "dokke:discover".toByteArray(Charsets.UTF_8)
     private val discoverReply = Regex("^dokke:(\\d{1,3}(\\.\\d{1,3}){3}):(\\d+)$")
@@ -76,6 +119,7 @@ class MainActivity : ComponentActivity() {
         serverUrl = prefs.getString("server_url", null) ?: getString(R.string.server_url)
         // permite override via intent extra (fácil de testar via am)
         intent.getStringExtra("server_url")?.let { serverUrl = it; prefs.edit().putString("server_url", it).apply() }
+        registerUpdateReceiver()
 
         web.settings.apply {
             javaScriptEnabled = true
@@ -139,6 +183,10 @@ class MainActivity : ComponentActivity() {
             }
             @android.webkit.JavascriptInterface
             fun appVersion(): String = BuildConfig.VERSION_NAME
+            @android.webkit.JavascriptInterface
+            fun requestUpdate(version: String) {
+                runOnUiThread { beginUpdate(version) }
+            }
         }, "DokkeAndroid")
         web.loadUrl(serverUrl)
         // descoberta automática: se o IP do Mac mudou, atualiza sozinho
@@ -222,8 +270,95 @@ class MainActivity : ComponentActivity() {
     private var firstResume = true
     override fun onResume() {
         super.onResume()
+        pendingUpdateVersion?.let { version ->
+            if (canInstallPackages()) {
+                pendingUpdateVersion = null
+                enqueueUpdate(version)
+            }
+        }
         if (firstResume) { firstResume = false; return }
         if (offlinePanel.visibility == View.VISIBLE) retryConnection() else web.reload()
+    }
+
+    private fun registerUpdateReceiver() {
+        val filter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(updateReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(updateReceiver, filter)
+        }
+        updateReceiverRegistered = true
+    }
+
+    private fun beginUpdate(version: String) {
+        if (updateDownloadId != null) {
+            showUpdateMessage("A atualização já está sendo baixada.")
+            return
+        }
+        val safeVersion = version.trim().replace(Regex("[^0-9A-Za-z._-]"), "")
+        if (safeVersion.isEmpty()) {
+            showUpdateMessage("Versão de atualização inválida.")
+            return
+        }
+        if (!canInstallPackages()) {
+            pendingUpdateVersion = safeVersion
+            AlertDialog.Builder(this)
+                .setTitle("Permitir atualização")
+                .setMessage("Para atualizar o Dokke, permita que este app instale a nova versão.")
+                .setNegativeButton("Agora não") { _, _ -> pendingUpdateVersion = null }
+                .setPositiveButton("Abrir configurações") { _, _ -> openInstallSettings() }
+                .show()
+            return
+        }
+        enqueueUpdate(safeVersion)
+    }
+
+    private fun canInstallPackages(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O || packageManager.canRequestPackageInstalls()
+    }
+
+    private fun openInstallSettings() {
+        try {
+            startActivity(Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:$packageName")))
+        } catch (_: Exception) {
+            startActivity(Intent(Settings.ACTION_SECURITY_SETTINGS))
+        }
+    }
+
+    private fun enqueueUpdate(version: String) {
+        val manager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val filename = "dokke-update-$version.apk"
+        val request = DownloadManager.Request(Uri.parse(updateApkUrl))
+            .setTitle("Atualização do Dokke")
+            .setDescription("Baixando a versão $version")
+            .setMimeType(updateMime)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(false)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setDestinationInExternalFilesDir(this, Environment.DIRECTORY_DOWNLOADS, filename)
+        updateDownloadId = manager.enqueue(request)
+        Toast.makeText(this, "Baixando a atualização…", Toast.LENGTH_LONG).show()
+    }
+
+    private fun installDownloadedApk(uri: Uri) {
+        if (!canInstallPackages()) {
+            showUpdateMessage("Permissão para instalar a atualização não concedida.")
+            return
+        }
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, updateMime)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            startActivity(intent)
+        } catch (_: Exception) {
+            showUpdateMessage("Não foi possível abrir o instalador do Android.")
+        }
+    }
+
+    private fun showUpdateMessage(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
     private fun buildOfflinePanel(): View {
@@ -340,6 +475,14 @@ class MainActivity : ComponentActivity() {
             cornerRadius = dp(radius).toFloat()
             if (stroke != Color.TRANSPARENT) setStroke(dp(1), stroke)
         }
+    }
+
+    override fun onDestroy() {
+        if (updateReceiverRegistered) {
+            unregisterReceiver(updateReceiver)
+            updateReceiverRegistered = false
+        }
+        super.onDestroy()
     }
 
     private fun dp(v: Int): Int = (v * resources.displayMetrics.density).toInt()

--- a/public/index.html
+++ b/public/index.html
@@ -485,7 +485,7 @@
   /* ---- aviso de atualização ---- */
   .up-banner{
     position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); left: 12px; right: 12px;
-    z-index: 80; display:flex; align-items:center; gap: 10px;
+    z-index: 120; display:flex; align-items:center; gap: 10px;
     padding: 12px 14px; border-radius: 18px;
     background: linear-gradient(165deg, rgba(255,255,255,.14), rgba(255,255,255,.05));
     border:1px solid rgba(255,255,255,.18);
@@ -502,9 +502,18 @@
   .up-banner .up-txt{ flex:1; min-width:0; }
   .up-banner .up-txt b{ display:block; font-size:13.5px; }
   .up-banner .up-txt span{ display:block; color:var(--ink-2); font-weight:500; font-size:12px; }
+  .up-banner .up-actions{ flex:0 0 auto; display:flex; align-items:center; gap:6px; }
+  .up-banner .up-download{ height:30px; padding:0 10px; border-radius:10px; border:1px solid rgba(255,255,255,.2);
+    background:rgba(10,132,255,.82); color:#fff; font-size:11.5px; font-weight:700; cursor:pointer; white-space:nowrap; }
+  .up-banner .up-download:active{ background:rgba(10,132,255,1); }
   .up-banner .up-x{ flex:0 0 auto; width:26px; height:26px; border-radius:8px; border:0; cursor:pointer;
     background: rgba(255,255,255,.1); color:var(--ink-2); font-size:14px; }
   .up-banner .up-x:active{ background: rgba(255,255,255,.2); }
+  @media (max-width:380px){
+    .up-banner{ gap:7px; padding:10px; }
+    .up-banner .up-icon{ width:27px; height:27px; }
+    .up-banner .up-download{ padding:0 8px; font-size:11px; }
+  }
 
   /* ---- login wall (pin de acesso) — líquido/glass ---- */
   .login-scrim{
@@ -623,7 +632,10 @@
       <b id="upTitle"></b>
       <span id="upSub"></span>
     </div>
-    <button class="up-x" id="upX" aria-label="Fechar aviso">✕</button>
+    <div class="up-actions">
+      <button class="up-download" id="upDownload">Baixar</button>
+      <button class="up-x" id="upX" aria-label="Fechar aviso">✕</button>
+    </div>
   </div>
 
   <aside class="drawer" id="drawer">
@@ -2082,39 +2094,56 @@
     }
     return 0;
   }
-  function showUpBanner(title, sub, href){
+  function showUpBanner(title, sub, href, version){
     const b = $("upBanner");
     $("upTitle").textContent = title;
     $("upSub").textContent = sub;
+    const download = $("upDownload");
+    const isAndroid = !!(window.DokkeAndroid && window.DokkeAndroid.requestUpdate);
+    download.textContent = isAndroid ? "Baixar" : "Abrir release";
+    download.onclick = function(e){
+      e.stopPropagation();
+      if (isAndroid){
+        try { window.DokkeAndroid.requestUpdate(String(version || "")); } catch (err) {}
+        return;
+      }
+      window.open(href, "_blank");
+    };
     b.classList.add("show");
-    b.onclick = function(){ window.open(href, "_blank"); };
   }
   $("upX").addEventListener("click", function(e){
     e.stopPropagation();
     $("upBanner").classList.remove("show");
   });
-  function checkVersion(){
+  function checkVersion(attempt){
+    attempt = attempt || 0;
     fetch("/api/version", { cache: "no-store" })
       .then(function(r){ return r.ok ? r.json() : null; })
       .then(function(v){
         if (!v || !v.local) return;
         const rel = v.latest;
-        // Mac (server embutido) desatualizado
+        // O servidor pode estar terminando a primeira consulta ao GitHub.
+        if (!rel && attempt < 2){
+          setTimeout(function(){ checkVersion(attempt + 1); }, 1500);
+          return;
+        }
+        // Android só avisa depois que a release existe no GitHub.
+        try {
+          const apkNow = window.DokkeAndroid && window.DokkeAndroid.appVersion();
+          if (apkNow && rel && rel.tag && cmpVer(rel.tag, apkNow) > 0){
+            showUpBanner("Nova atualização do Dokke",
+              "Versão " + rel.tag + " disponível. Escolha quando baixar.",
+              rel.apkUrl || "https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk",
+              rel.tag);
+            return;
+          }
+        } catch (e) {}
+        // Mac (servidor embutido) desatualizado
         if (rel && rel.tag && cmpVer(rel.tag, v.local.tag) > 0){
           showUpBanner("App do Mac desatualizado",
             "Nova versão " + rel.tag + " disponível — atualize o Dokke no computador",
             rel.htmlUrl || "https://github.com/felipenalves/Dokke/releases/latest");
-          return;
         }
-        // APK desatualizado (só quando roda dentro do app Android)
-        try {
-          const apkNow = window.DokkeAndroid && window.DokkeAndroid.appVersion();
-          if (apkNow && cmpVer(v.local.apkVersion, apkNow) > 0){
-            showUpBanner("App Android desatualizado",
-              "Nova versão " + v.local.apkVersion + " disponível — baixe o APK atualizado",
-              "https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk");
-          }
-        } catch (e) {}
       })
       .catch(function(){});
   }
@@ -2126,9 +2155,9 @@
     loadInstalled();
   }
 
+  checkVersion();
   loadHealth();
   boot();
-  checkVersion();
 
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("/sw.js").catch(function() {});

--- a/test/ui.test.mjs
+++ b/test/ui.test.mjs
@@ -31,6 +31,9 @@ test("GET / serve as 2 telas (apps + recentes) liquid glass", async () => {
     assert.match(html, /\.ddiv/, "divisor | estilo dock presente");
     assert.match(html, /\.dcard\.front/, "card da frente com classe front");
     assert.doesNotMatch(html, /toque em \+ para adicionar/, "copy morta do botão + removida");
+    assert.match(html, /id="upDownload"/, "aviso de atualização deve ter ação explícita");
+    assert.match(html, /DokkeAndroid\.requestUpdate/, "Android deve controlar o download da atualização");
+    assert.match(html, /cmpVer\(rel\.tag, apkNow\)/, "APK deve comparar a versão instalada com a release");
   } finally { await close(); }
 });
 


### PR DESCRIPTION
## O que mudou

- mostra aviso quando existe uma release mais nova no GitHub;
- adiciona botão explícito para baixar;
- pede permissão para instalar fontes externas;
- baixa o APK oficial via DownloadManager;
- abre o instalador oficial do Android para confirmação;
- mantém a UI no padrão visual atual;
- adiciona teste do fluxo de atualização.

## Validação

- `npm test`: 100/100;
- `./gradlew assembleDebug`: passou;
- `git diff --check`: passou.

A atualização só aparece quando a tag da release do GitHub for maior que a versão instalada.