### PR TITLE
chore(release): preparar v0.2.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId = "com.dokke.app"
         minSdk = 21
         targetSdk = 34
-        versionCode = 2
-        versionName = "0.1.0"
+        versionCode = 3
+        versionName = "0.2.0"
     }
 
     compileOptions {

--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSApplicationCategoryType</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dokke",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dokke",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "ws": "^8.21.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dokke",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/version.json
+++ b/public/version.json
@@ -1,1 +1,1 @@
-{"tag": "v0.1.0", "apkVersion": "0.1.0"}
+{"tag": "v0.2.0", "apkVersion": "0.2.0"}


### PR DESCRIPTION
## Release v0.2.0

- atualiza a versao do app Android para 0.2.0
- atualiza a versao do app macOS para 0.2.0
- atualiza o manifesto de versao usado pelo fluxo de atualizacao

Validacoes executadas:
- npm test
- ./gradlew assembleDebug
- swift build