### PR TITLE
feat(i18n): adiciona inglês e detecção automática no Dokke

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,106 @@
+<p align="center">
+  <img src="docs/public/dokke-icon.png" width="120" alt="Dokke">
+</p>
+
+<h1 align="center">Dokke</h1>
+
+<p align="center"><a href="README.md">Leia este README em português</a></p>
+
+<p align="center">
+  <b>An app dock that syncs from your Mac to any device on your LAN.</b><br>
+  It started with an old Galaxy J5 — today it runs on Android, iPhone, or any browser.
+</p>
+
+Dokke is an app dock manager: pin, reorder, and open Mac apps from another device on the same network.
+
+## Installation
+
+For a no-terminal installation, open the [installation page](https://dokke.vercel.app/).
+
+### Mac — main host
+
+[Download Dokke for macOS](https://github.com/felipenalves/Dokke/releases/latest/download/Dokke-macOS.dmg), open the `.dmg`, drag Dokke to Applications, and launch it.
+
+The Mac is the host: it runs the server and makes the dock available to other devices on the same network.
+
+> If macOS blocks the first launch, open **System Settings → Privacy & Security → Security → Open Anyway → Open**. Dokke is distributed outside the App Store.
+
+### Android
+
+[Download the APK](https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk) and install it. Then open Dokke on the Mac and use the URL and PIN shown in the **Connect** tab.
+
+### iPhone
+
+iPhone uses the browser PWA. Open the URL shown in the Mac app in Safari and choose **Add to Home Screen**. iPhone requires an HTTPS URL; the installation page describes the current path.
+
+> Windows is not available yet. The installation page will show a button when an installable version exists.
+
+## How it works
+
+1. The **Mac app** manages pinned apps and runs the local server.
+2. The **Node.js server** syncs the dock through WebSocket and serves the PWA.
+3. The **device** receives changes in real time.
+4. Tapping an app on the device opens it on the Mac.
+5. UDP discovery finds the Mac on the local network without manual IP configuration.
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Mac app | Swift, SwiftUI, MenuBarExtra, Liquid Glass (macOS 26+) |
+| Server | Node.js, `ws`, plain HTTP |
+| PWA | Vanilla HTML/CSS/JS, CSS Grid, backdrop-filter blur |
+| Android | Kotlin, WebView wrapper |
+| Sync | WebSocket and UDP discovery |
+
+## Development
+
+For source builds, use macOS 14+, Xcode Command Line Tools, and Node.js 20+:
+
+```sh
+git clone https://github.com/felipenalves/Dokke.git
+cd Dokke
+cd mac && ./install.sh --open
+```
+
+Run the server directly:
+
+```sh
+npm install
+node server.js
+# → http://localhost:3000
+```
+
+The Mac app starts the server automatically. The Connect tab shows the URL and PIN for other devices.
+
+## Features
+
+- **Mac app:** sidebar, 4×2 dock grid, app picker, drag-to-reorder, native icons, menu bar, and automatic server startup.
+- **PWA/APK:** pinned apps, open apps, long-press to pin, real-time updates, and automatic UI refresh.
+- **Language:** choose Português or English in the PWA, Mac app, and documentation. The local choice persists on that device.
+
+## Authentication
+
+All `/api/*` routes require a 4-digit PIN, except `/health`, `/api/probe`, and `/api/auth`. Requests from loopback (the Dokke app on the Mac) are allowed directly.
+
+The PIN is generated on first boot and can be regenerated from the Mac app's **Connect** tab. Regenerating it invalidates device cookies; connected devices will request the new code.
+
+## API
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/health` | Public health check |
+| GET | `/api/apps` | Pinned apps and running processes |
+| GET | `/api/apps/installed` | Installed Mac apps |
+| POST | `/api/config/pinned` | Pin an app |
+| PUT | `/api/config/pinned` | Replace the pinned list |
+| DELETE | `/api/config/pinned/:app` | Unpin an app |
+| POST | `/api/apps/:name/activate` | Activate an app on the Mac |
+
+## Tests
+
+```sh
+npm test
+```
+
+See the [Portuguese README](README.md) for the complete reference and current release notes.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">Dokke</h1>
 
+<p align="center"><a href="README.en.md">Read this README in English</a></p>
+
 <p align="center">
   <b>Dock de apps que sincroniza do Mac pra qualquer device na LAN.</b><br>
   Nasceu de um Galaxy J5 velho parado em casa — hoje roda em qualquer Android, iPhone ou navegador.

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -13,29 +13,70 @@ const pattern = Array.from({ length: 15 }, (_, index) => {
   return `<span style="--offset: ${offset}ch">${patternLine} ${patternLine}</span>`;
 }).join("");
 
+const LANDING_LANGUAGE_KEY = "dokke_landing_lang";
+const LANDING_COPY = {
+  "pt-BR": {
+    "aria.language": "Idioma", "nav.aria": "Navegação principal", "nav.features": "Recursos", "nav.community": "Comunidade", "nav.docs": "Docs", "nav.github": "GitHub",
+    "hero.aria": "Pressionar o ícone do Dokke", "hero.eyebrow": "DOKKE · SEU MAC, EM QUALQUER TELA", "hero.title": "Os apps do seu Mac.<br /><em>Em qualquer tela.</em>", "hero.copy": "Fixe no Mac. Abra no Android, iPhone ou navegador — na mesma rede, sem conta.", "hero.mac": "Baixar para macOS", "hero.android": "Baixar para Android", "hero.meta": "macOS 14+ · Android · iPhone via PWA · grátis", "hero.windows": "Em breve|Dokke para Windows",
+    "features.kicker": "02 / o que tem no dokke", "features.title": "O dock do seu Mac,<br /><em>sem ficar preso ao Mac.</em>", "feature.1.title": "Acesse o que já está no seu Mac.", "feature.1.copy": "Fixe os apps uma vez. Abra pelo Android, iPhone ou navegador na mesma rede.", "feature.2.title": "Sem conta. Sem nuvem.", "feature.2.copy": "O Dokke conecta seus dispositivos diretamente. Menos cadastro, menos coisa para configurar.", "feature.3.title": "Do download ao primeiro toque.", "feature.3.copy": "Baixe o DMG, arraste para Aplicativos e escolha seus apps. O celular encontra o Mac sozinho.", "feature.3.points": "PIN de acesso|Tempo real|APK + PWA|MIT",
+    "roadmap.kicker": "03 / próximos capítulos", "roadmap.title": "O que vem<br /><em>depois.</em>", "roadmap.intro": "O que já existe está marcado. O resto são os próximos atalhos para deixar o Mac ainda mais acessível.", "roadmap.available": "disponível agora", "roadmap.exists": "já existe", "roadmap.1.title": "Alternar entre os aplicativos abertos", "roadmap.1.copy": "Veja o que está rodando no Mac e troque de app direto pelo dock.", "roadmap.2.title": "Controlar o OBS Studio", "roadmap.2.copy": "Mude a cena, inicie ou pare a gravação e acompanhe a live sem sair do celular.", "roadmap.3.title": "Volume e mídia", "roadmap.3.copy": "Aumente, reduza, pause e continue o que está tocando no Mac.", "roadmap.4.title": "Um teclado só de emoji", "roadmap.4.copy": "Puxe a mesma ideia da tecla de emoji do Mac para responder, criar e compartilhar sem trocar de tela.", "roadmap.5.title": "Crie todos os seus fluxos de trabalho ✨", "roadmap.5.copy": "Conecte o Dokke ao Apple Shortcuts e transforme ações repetidas em um toque.",
+    "community.kicker": "04 / construção em comunidade", "community.title": "O próximo atalho<br /><em>pode vir de você.</em>", "community.intro": "O Dokke é construído em comunidade. Encontrou um bug, teve uma ideia ou quer ajudar? Comente no GitHub — é lá que o projeto é analisado e evolui.", "community.cta": "Comentar no GitHub", "community.aria": "Como contribuir com o Dokke", "community.1.title": "Encontrou um problema?", "community.1.copy": "Abra uma Issue e conte a versão, o dispositivo e os passos para reproduzir.", "community.2.title": "Imaginou uma feature?", "community.2.copy": "Abra uma Discussion em Ideas. O que a comunidade pedir pode virar o próximo lançamento.", "community.3.title": "Quer construir junto?", "community.3.copy": "Leia como contribuir, testar e manter cada mudança pequena e útil.", "club.kicker": "Outro produto · Documente Club", "club.title": "IA aplicada para quem está construindo.", "club.copy": "Uma comunidade paga para builders, entusiastas de IA e solo founders que querem implementar IA de verdade em projetos e negócios.", "club.cta": "Conhecer o Documente Club",
+    "faq.kicker": "05 / perguntas frequentes", "faq.title": "Antes de instalar,<br /><em>sem surpresa.</em>", "faq.1.q": "Preciso instalar Node.js?", "faq.1.a": "Não para usar o DMG. O Node já vem embutido no Dokke para Mac. Ele só é necessário para quem quer rodar ou desenvolver pelo código.", "faq.2.q": "O Mac e o celular precisam estar na mesma rede?", "faq.2.a": "Sim. O Dokke é local-first: o Mac e o dispositivo precisam conseguir conversar pela mesma rede Wi-Fi ou LAN.", "faq.3.q": "Como acesso pelo iPhone?", "faq.3.a": "Abra no Safari o endereço mostrado pelo Dokke e, se quiser, use Adicionar à Tela de Início. O iPhone funciona como PWA.", "faq.4.q": "O Dokke envia meus dados para a nuvem?", "faq.4.a": "Não. O Mac conversa diretamente com os dispositivos na sua rede local. O Dokke não precisa de conta ou servidor externo.", "faq.5.q": "O que faço se o macOS bloquear o app?", "faq.5.a": "Clique com o botão direito no Dokke.app, escolha Abrir e confirme. Se essa opção não aparecer, abra Ajustes do Sistema → Privacidade e Segurança → Segurança → Abrir Mesmo Assim → Abrir. Esse aviso pode aparecer porque o Dokke é distribuído fora da App Store.", "faq.6.q": "Já existe uma versão para Windows?", "faq.6.a": "Ainda não. A primeira release pública é para macOS, com Android e PWA como clientes. Windows está planejado para uma próxima etapa.", "footer.aria": "Links sociais", "footer.back": "Voltar ao início", "footer.note": "© 2026 Dokke · um produto de Felipe Natanael"
+  },
+  en: {
+    "aria.language": "Language", "nav.aria": "Main navigation", "nav.features": "Features", "nav.community": "Community", "nav.docs": "Docs", "nav.github": "GitHub",
+    "hero.aria": "Press the Dokke icon", "hero.eyebrow": "DOKKE · YOUR MAC, ON ANY SCREEN", "hero.title": "Your Mac apps.<br /><em>On any screen.</em>", "hero.copy": "Pin on your Mac. Open on Android, iPhone, or browser — on the same network, no account.", "hero.mac": "Download for macOS", "hero.android": "Download for Android", "hero.meta": "macOS 14+ · Android · iPhone via PWA · free", "hero.windows": "Coming soon|Dokke for Windows",
+    "features.kicker": "02 / what dokke has", "features.title": "Your Mac dock,<br /><em>without being stuck to your Mac.</em>", "feature.1.title": "Access what's already on your Mac.", "feature.1.copy": "Pin your apps once. Open them from Android, iPhone, or a browser on the same network.", "feature.2.title": "No account. No cloud.", "feature.2.copy": "Dokke connects your devices directly. Less signup, less to configure.", "feature.3.title": "From download to first tap.", "feature.3.copy": "Download the DMG, drag it to Applications, and choose your apps. Your phone finds the Mac automatically.", "feature.3.points": "Access PIN|Real time|APK + PWA|MIT",
+    "roadmap.kicker": "03 / what's next", "roadmap.title": "What comes<br /><em>next.</em>", "roadmap.intro": "What already exists is marked. The rest are the next shortcuts to make your Mac even more accessible.", "roadmap.available": "available now", "roadmap.exists": "available", "roadmap.1.title": "Switch between open apps", "roadmap.1.copy": "See what's running on your Mac and switch apps directly from the dock.", "roadmap.2.title": "Control OBS Studio", "roadmap.2.copy": "Change the scene, start or stop recording, and follow the live stream from your phone.", "roadmap.3.title": "Volume and media", "roadmap.3.copy": "Turn up, turn down, pause, and resume what's playing on your Mac.", "roadmap.4.title": "An emoji-only keyboard", "roadmap.4.copy": "Bring the Mac emoji key idea to replies, creation, and sharing without changing screens.", "roadmap.5.title": "Create all your workflows ✨", "roadmap.5.copy": "Connect Dokke to Apple Shortcuts and turn repeated actions into one tap.",
+    "community.kicker": "04 / built in community", "community.title": "The next shortcut<br /><em>could come from you.</em>", "community.intro": "Dokke is built in community. Found a bug, have an idea, or want to help? Comment on GitHub — that's where the project is reviewed and evolves.", "community.cta": "Comment on GitHub", "community.aria": "How to contribute to Dokke", "community.1.title": "Found a problem?", "community.1.copy": "Open an Issue and share the version, device, and steps to reproduce it.", "community.2.title": "Imagined a feature?", "community.2.copy": "Open a Discussion in Ideas. What the community asks for could become the next release.", "community.3.title": "Want to build together?", "community.3.copy": "Read how to contribute, test, and keep every change small and useful.", "club.kicker": "Another product · Documente Club", "club.title": "Applied AI for people building.", "club.copy": "A paid community for builders, AI enthusiasts, and solo founders who want to implement AI for real in projects and businesses.", "club.cta": "Explore Documente Club",
+    "faq.kicker": "05 / frequently asked questions", "faq.title": "Before you install,<br /><em>no surprises.</em>", "faq.1.q": "Do I need to install Node.js?", "faq.1.a": "Not to use the DMG. Node is bundled with Dokke for Mac. It is only needed if you want to run or develop from source.", "faq.2.q": "Do the Mac and phone need to be on the same network?", "faq.2.a": "Yes. Dokke is local-first: the Mac and device must be able to communicate over the same Wi-Fi or LAN.", "faq.3.q": "How do I access it from iPhone?", "faq.3.a": "Open the address shown by Dokke in Safari and, if you want, choose Add to Home Screen. iPhone works as a PWA.", "faq.4.q": "Does Dokke send my data to the cloud?", "faq.4.a": "No. Your Mac talks directly to devices on your local network. Dokke does not need an account or external server.", "faq.5.q": "What if macOS blocks the app?", "faq.5.a": "Right-click Dokke.app, choose Open, and confirm. If that option does not appear, open System Settings → Privacy & Security → Security → Open Anyway → Open. This may appear because Dokke is distributed outside the App Store.", "faq.6.q": "Is there a Windows version yet?", "faq.6.a": "Not yet. The first public release is for macOS, with Android and PWA as clients. Windows is planned for a later stage.", "footer.aria": "Social links", "footer.back": "Back to top", "footer.note": "© 2026 Dokke · a Felipe Natanael product"
+  }
+};
+
+function detectLandingLanguage(language = navigator.language) {
+  if (typeof language !== "string" || !language.trim()) return "pt-BR";
+  return language.toLowerCase().startsWith("pt") ? "pt-BR" : "en";
+}
+
+function getLandingLanguage() {
+  try {
+    const saved = localStorage.getItem(LANDING_LANGUAGE_KEY);
+    if (saved === "pt-BR" || saved === "en") return saved;
+  } catch {}
+  return detectLandingLanguage();
+}
+
+let landingLanguage = getLandingLanguage();
+
 document.querySelector("#app").innerHTML = `
   <div class="hero-page" id="section-01">
     <div class="code-pattern" aria-hidden="true">${pattern}</div>
 
     <header class="site-header">
-      <nav class="nav-shell" aria-label="Navegação principal">
-        <a class="wordmark" href="#section-01" aria-label="Dokke início">Dokke</a>
+      <nav class="nav-shell" aria-label="Navegação principal" data-i18n-aria="nav.aria">
+        <a class="wordmark" href="#section-01" aria-label="Dokke início" data-i18n-aria="footer.back">Dokke</a>
         <div class="nav-links">
           <a href="#features">Recursos</a>
           <a href="#community">Comunidade</a>
           <a href="https://github.com/felipenalves/Dokke#leia-me-primeiro">Docs</a>
           <a href="https://github.com/felipenalves/Dokke">GitHub</a>
         </div>
+        <div class="nav-actions">
+        <div class="language-toggle" data-language-toggle aria-label="Idioma" data-i18n-aria="aria.language">
+          <button type="button" data-language="pt-BR" aria-pressed="true">PT</button>
+          <button type="button" data-language="en" aria-pressed="false">EN</button>
+        </div>
         <a class="github-link" href="https://github.com/felipenalves/Dokke" target="_blank" rel="noreferrer">
           <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" fill="currentColor"/></svg>
           <span>GitHub</span>
         </a>
+        </div>
       </nav>
     </header>
 
     <main>
       <section class="hero" aria-labelledby="hero-title">
-        <button type="button" class="hero-emblem" aria-label="Pressionar o ícone do Dokke">
+        <button type="button" class="hero-emblem" aria-label="Pressionar o ícone do Dokke" data-i18n-aria="hero.aria">
           <img class="hero-icon" src="${dokkeHeroIcon}" alt="" />
         </button>
 
@@ -210,6 +251,81 @@ document.querySelector("#app").innerHTML = `
     </nav>
   </footer>
 `;
+
+const LANDING_SELECTORS = {
+  ".nav-shell": ["nav.aria", "aria"],
+  ".nav-links a:nth-child(1)": ["nav.features"],
+  ".nav-links a:nth-child(2)": ["nav.community"],
+  ".nav-links a:nth-child(3)": ["nav.docs"],
+  ".nav-actions .github-link span": ["nav.github"],
+  ".eyebrow": ["hero.eyebrow"],
+  "#hero-title": ["hero.title", "html"],
+  ".hero-copy": ["hero.copy"],
+  ".hero-actions .primary-button:nth-of-type(1) span": ["hero.mac"],
+  ".hero-actions .primary-button--android span": ["hero.android"],
+  ".hero-meta": ["hero.meta"],
+  ".features-section .section-kicker": ["features.kicker"],
+  "#features-title": ["features.title", "html"],
+  ".feature-card:nth-child(1) h3": ["feature.1.title"],
+  ".feature-card:nth-child(1) p": ["feature.1.copy"],
+  ".feature-card:nth-child(2) h3": ["feature.2.title"],
+  ".feature-card:nth-child(2) p": ["feature.2.copy"],
+  ".feature-card:nth-child(3) h3": ["feature.3.title"],
+  ".feature-card:nth-child(3) p": ["feature.3.copy"],
+  ".roadmap-heading .section-kicker": ["roadmap.kicker"],
+  "#roadmap-title": ["roadmap.title", "html"],
+  ".roadmap-intro": ["roadmap.intro"],
+  ".roadmap-item:nth-child(1) .roadmap-status": ["roadmap.exists"],
+  ".roadmap-item:nth-child(1) h3": ["roadmap.1.title"], ".roadmap-item:nth-child(1) p": ["roadmap.1.copy"],
+  ".roadmap-item:nth-child(2) h3": ["roadmap.2.title"], ".roadmap-item:nth-child(2) p": ["roadmap.2.copy"],
+  ".roadmap-item:nth-child(3) h3": ["roadmap.3.title"], ".roadmap-item:nth-child(3) p": ["roadmap.3.copy"],
+  ".roadmap-item:nth-child(4) h3": ["roadmap.4.title"], ".roadmap-item:nth-child(4) p": ["roadmap.4.copy"],
+  ".roadmap-item:nth-child(5) h3": ["roadmap.5.title"], ".roadmap-item:nth-child(5) p": ["roadmap.5.copy"],
+  ".community-heading .section-kicker": ["community.kicker"], "#community-title": ["community.title", "html"], ".community-intro": ["community.intro"], ".community-cta": ["community.cta"], ".community-actions": ["community.aria", "aria"],
+  ".community-action:nth-child(1) h3": ["community.1.title"], ".community-action:nth-child(1) p": ["community.1.copy"],
+  ".community-action:nth-child(2) h3": ["community.2.title"], ".community-action:nth-child(2) p": ["community.2.copy"],
+  ".community-action:nth-child(3) h3": ["community.3.title"], ".community-action:nth-child(3) p": ["community.3.copy"],
+  ".community-club-kicker": ["club.kicker"], ".community-club h3": ["club.title"], ".community-club p:not(.community-club-kicker)": ["club.copy"], ".community-club-cta": ["club.cta"],
+  ".faq-heading .section-kicker": ["faq.kicker"], "#faq-title": ["faq.title", "html"],
+  ".faq-list details:nth-child(1) summary": ["faq.1.q"], ".faq-list details:nth-child(1) p": ["faq.1.a"],
+  ".faq-list details:nth-child(2) summary": ["faq.2.q"], ".faq-list details:nth-child(2) p": ["faq.2.a"],
+  ".faq-list details:nth-child(3) summary": ["faq.3.q"], ".faq-list details:nth-child(3) p": ["faq.3.a"],
+  ".faq-list details:nth-child(4) summary": ["faq.4.q"], ".faq-list details:nth-child(4) p": ["faq.4.a"],
+  ".faq-list details:nth-child(5) summary": ["faq.5.q"], ".faq-list details:nth-child(5) p": ["faq.5.a"],
+  ".faq-list details:nth-child(6) summary": ["faq.6.q"], ".faq-list details:nth-child(6) p": ["faq.6.a"],
+  ".footer-brand": ["footer.back", "aria"], ".footer-note": ["footer.note"], ".footer-links": ["footer.aria", "aria"]
+};
+
+function applyLandingLanguage() {
+  const copy = LANDING_COPY[landingLanguage];
+  Object.entries(LANDING_SELECTORS).forEach(([selector, [key, mode]]) => {
+    const element = document.querySelector(selector);
+    if (!element || !copy[key]) return;
+    if (mode === "html") element.innerHTML = copy[key];
+    else if (mode === "aria") element.setAttribute("aria-label", copy[key]);
+    else element.textContent = copy[key];
+  });
+  const windows = copy["hero.windows"].split("|");
+  const windowsNote = document.querySelector(".windows-note");
+  if (windowsNote) windowsNote.innerHTML = `<span>${windows[0]}</span> ${windows[1]}`;
+  const points = copy["feature.3.points"].split("|");
+  document.querySelectorAll(".feature-card:nth-child(3) .feature-points span").forEach((element, index) => {
+    if (points[index]) element.textContent = points[index];
+  });
+  document.querySelectorAll(".language-toggle [data-language]").forEach((button) => {
+    button.setAttribute("aria-pressed", String(button.dataset.language === landingLanguage));
+  });
+  document.documentElement.lang = landingLanguage;
+}
+
+document.querySelectorAll(".language-toggle [data-language]").forEach((button) => {
+  button.addEventListener("click", () => {
+    landingLanguage = button.dataset.language === "en" ? "en" : "pt-BR";
+    try { localStorage.setItem(LANDING_LANGUAGE_KEY, landingLanguage); } catch {}
+    applyLandingLanguage();
+  });
+});
+applyLandingLanguage();
 
 const heroEmblem = document.querySelector(".hero-emblem");
 const heroSection = document.querySelector(".hero");

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -103,6 +103,12 @@ a { color: inherit; }
 .nav-links a { text-decoration: none; transition: color .2s ease; }
 .nav-links a:hover { color: var(--ink); }
 
+.nav-actions { display: inline-flex; align-items: center; gap: 8px; }
+.language-toggle { display: inline-flex; align-items: center; gap: 2px; padding: 3px; border: 1px solid rgba(255,255,255,.38); border-radius: 999px; background: rgba(255,255,255,.28); }
+.language-toggle button { border: 0; border-radius: 999px; background: transparent; color: #716d78; cursor: pointer; font: 700 10px/1 Inter, sans-serif; padding: 7px 8px; }
+.language-toggle button[aria-pressed="true"] { background: var(--ink); color: #fff; }
+.language-toggle button:focus-visible { outline: 2px solid var(--hero-orange); outline-offset: 2px; }
+
 .download-link,
 .github-link {
   display: inline-flex;
@@ -794,6 +800,10 @@ a:focus-visible { outline: 2px solid var(--blue); outline-offset: 4px; }
   .site-header { width: min(calc(100% - 28px), 676px); margin-top: 14px; }
   .nav-shell { grid-template-columns: auto auto; justify-content: space-between; gap: 10px; padding-left: 16px; }
   .nav-links { display: none; }
+  .nav-actions { min-width: 0; gap: 6px; }
+  .nav-actions .github-link { min-height: 34px; padding: 0 12px; }
+  .language-toggle { padding: 2px; }
+  .language-toggle button { padding: 7px 6px; }
   .hero { min-height: calc(100svh - 66px); padding-top: 56px; }
   .hero-emblem { width: 132px; height: 132px; margin-bottom: 29px; }
   .hero-icon { width: 124px; height: 124px; }

--- a/docs/superpowers/plans/2026-08-28-dokke-issue-19-i18n.md
+++ b/docs/superpowers/plans/2026-08-28-dokke-issue-19-i18n.md
@@ -1,0 +1,125 @@
+# Dokke #19 — suporte a inglês e detecção de idioma — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Entregar suporte consistente a `pt-BR` e `en` no PWA/APK, no app macOS e na landing/docs, com detecção automática no PWA/APK e seleção manual persistente no macOS/landing, sem perder os contratos visuais e funcionais atuais do `develop`.
+
+**Architecture:** Cada superfície terá um pequeno catálogo local de duas línguas. O PWA/APK detectarão o idioma via `navigator.language` ao abrir; o macOS usará um `LanguageStore` observável em `EnvironmentObject` com escolha persistente; a landing manterá o template atual em `docs/src/main.js`, detectará o idioma inicial e permitirá uma preferência manual persistente. Dados do servidor, nomes de apps, URLs, PINs e números continuarão sendo interpolados como texto, fora dos catálogos.
+
+**Tech Stack:** JavaScript vanilla inline, DOM existente do PWA, SwiftUI/AppKit, `UserDefaults`, Vite em `docs/`, Node test runner existente, `swift build`.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-dokke-issue-19-i18n-design.md`
+
+## Global Constraints
+
+- Trabalhar somente na branch isolada `feature/issue-19-i18n`, baseada em `develop`.
+- Não aprovar, fazer merge ou copiar integralmente a PR #20; usar apenas os insights descritos na spec.
+- Não substituir `public/index.html`, `docs/src/main.js` ou views SwiftUI por versões da PR comunitária.
+- Não alterar autenticação, API, WebSocket, ordenação, limites, abertura de apps, OBS ou comportamento de websites.
+- Preservar o grid, paginação, gestos, cards, drawer, modal, safe area e contratos visuais do PWA; preservar sidebar, semáforos, canvas e dimensões da janela macOS; preservar estrutura, animações e responsividade da landing.
+- Não criar commit, push, PR, release ou deploy nesta execução sem autorização separada.
+- Antes de cada alteração, conferir `git status --short`; no fim, conferir `git diff --check` e revisar o diff por escopo.
+
+---
+
+## Task 1 — Criar contratos de teste para o i18n do PWA
+
+**Files:** `test/issue-19-i18n.test.mjs` (novo), `public/index.html` (leitura para definir os contratos).
+
+- [ ] Escrever testes que carreguem `public/index.html` como texto e exijam dois catálogos explícitos, `pt-BR` e `en`, com conjuntos de chaves idênticos. As chaves devem cobrir login, dock, recents, modal, toast, OBS, update banner e acessibilidade.
+- [ ] Escrever testes para `document.documentElement.lang` e detecção do idioma do navegador, sem preferência manual no PWA/APK.
+- [ ] Escrever testes que garantam a ausência de controles manuais de idioma no estado pré-login e no shell autenticado.
+- [ ] Escrever testes para interpolação segura de valores dinâmicos: o catálogo não deve conter nomes de apps, URLs, PINs ou HTML funcional.
+- [ ] Escrever testes de regressão que continuem exigindo os seletores/strings estruturais já cobertos por `test/ui.test.mjs`, `test/pinned-limit-ui.test.mjs`, `test/obs.test.mjs` e `test/mac-app-slides-ui.test.mjs`.
+- [ ] Rodar `node --test test/issue-19-i18n.test.mjs` e confirmar que os testes falham pela ausência da implementação, sem mascarar falhas de parsing.
+
+**Implementation shape to drive:**
+
+```js
+const I18N = { "pt-BR": { /* same keys as en */ }, en: { /* same keys as pt-BR */ } };
+function detectLanguage(language = navigator.language) {}
+function getInitialLanguage() {}
+function t(key, values = {}) {}
+```
+
+## Task 2 — Implementar detecção e tradução no PWA/APK
+
+**Files:** `public/index.html`; `test/issue-19-i18n.test.mjs`.
+
+- [ ] Implementar o catálogo `I18N` com paridade de chaves e textos PT-BR/inglês para todos os textos funcionais visíveis e de acessibilidade encontrados no fluxo atual.
+- [ ] Implementar `detectLanguage`, `getInitialLanguage` e `t` com esta regra: idioma do navegador começando por `pt` → `pt-BR`; qualquer outro idioma → inglês; `pt-BR` somente quando o ambiente não puder ser lido.
+- [ ] Aplicar o idioma detectado na abertura, atualizando `document.documentElement.lang` e todos os nós estáticos/dinâmicos renderizados por login, dock, recents, modal, toasts, OBS, update banner e estados online/offline.
+- [ ] Interpolar nomes, URLs, PINs, limites e respostas do servidor como texto; manter qualquer ênfase visual no template/DOM, nunca no catálogo.
+- [ ] Não adicionar controle manual de idioma ao PWA/APK nem reservar espaço de layout para ele.
+- [ ] Garantir que trocar idioma não reinicialize autenticação, socket, paginação, página atual, seleção de app, OBS ou estado de modal.
+- [ ] Atualizar os testes estáticos para verificar as funções, chaves, detecção, `lang`, ausência de persistência manual e ausência dos hard-codes críticos.
+- [ ] Rodar `node --test test/issue-19-i18n.test.mjs test/ui.test.mjs test/pinned-limit-ui.test.mjs test/obs.test.mjs`.
+
+**Regression check:** os testes devem continuar encontrando `launchpad`, `launchpadTrack`, `dots`, handlers de gesto e os seletores atuais; nenhuma regra de layout do PWA deve ser reescrita para acomodar o idioma.
+
+## Task 3 — Criar o armazenamento de idioma e traduzir o macOS
+
+**Files:** `mac/Sources/LanguageStore.swift` (novo), `mac/Sources/DokkeApp.swift`, `mac/Sources/ContentView.swift`, `mac/Sources/AppPickerSheet.swift`, `mac/Sources/DockGridView.swift`, `mac/Sources/DockIcon.swift`, `mac/Sources/DokkeUpdateManager.swift`, `test/issue-19-i18n.test.mjs`.
+
+- [ ] Escrever primeiro os contratos estáticos que exigem `LanguageStore`, enum de dois idiomas, persistência por `UserDefaults`, detecção inicial pelo idioma preferido do sistema e `Picker` na tela `Conectar`.
+- [ ] Criar `DokkeLanguage: String, CaseIterable, Identifiable` com valores persistíveis `pt-BR` e `en`, nomes de seleção `Português` e `English` e uma chave de `UserDefaults` exclusiva do idioma.
+- [ ] Criar `LanguageStore: ObservableObject` com `@Published var selected`, inicialização por `UserDefaults` injetável para teste, fallback determinístico e método de seleção que grava imediatamente a preferência.
+- [ ] Substituir o `I18n` dependente apenas de `Locale.preferredLanguages` por uma camada que receba o idioma selecionado do `LanguageStore` e devolva os textos das views atuais.
+- [ ] Instanciar o `LanguageStore` no `DokkeApp` e injetá-lo tanto em `ContentView` quanto em `MenuBarView`/cenas relacionadas via `.environmentObject`.
+- [ ] Adicionar o `Picker` de idioma como uma linha na view existente de `Conectar`, sem nova navegação, nova janela ou alteração da largura/altura estrutural da janela.
+- [ ] Trocar textos visíveis, mensagens de erro, diálogos, rótulos de acessibilidade, menu bar, picker de apps, dock, atualização e conexão nos arquivos atuais, mantendo nomes de apps, URLs, PINs e números fora da tradução.
+- [ ] Fazer as views lerem o `LanguageStore` observado para atualizar imediatamente após a troca e manter a escolha no relançamento.
+- [ ] Atualizar os contratos para assegurar que a sidebar continue com os itens/ícones atuais, que o `Picker` apareça somente em `Conectar` e que os marcadores de layout e semáforos não sejam removidos.
+- [ ] Rodar `node --test test/issue-19-i18n.test.mjs test/mac-connection-ui.test.mjs test/mac-app-slides-ui.test.mjs test/mac-picker-loading.test.mjs` e `cd mac && swift build`.
+
+**Swift shape to drive:**
+
+```swift
+enum DokkeLanguage: String, CaseIterable, Identifiable {
+  case portuguese = "pt-BR"
+  case english = "en"
+  var id: String { rawValue }
+}
+
+final class LanguageStore: ObservableObject {
+  @Published var selected: DokkeLanguage
+  init(defaults: UserDefaults = .standard, preferredLanguages: [String] = Locale.preferredLanguages) {}
+  func select(_ language: DokkeLanguage) {}
+}
+```
+
+## Task 4 — Adicionar i18n à landing/docs e README em inglês
+
+**Files:** `docs/src/main.js`, `docs/src/style.css`, `README.md`, `README.en.md` (novo), `test/issue-19-i18n.test.mjs`, `test/docs-hero-motion.test.mjs`.
+
+- [ ] Escrever contratos que exijam catálogo PT/EN com paridade, detecção por `navigator.language`, toggle persistente, `document.documentElement.lang` e links de troca entre `README.md` e `README.en.md`.
+- [ ] Extrair a cópia estática atual de `docs/src/main.js` para um objeto de traduções PT/EN ou estrutura equivalente, cobrindo navegação, hero, botões, recursos, roadmap, comunidade, FAQ, rodapé e labels/ARIA.
+- [ ] Renderizar a landing inicialmente pelo idioma salvo; na ausência dele, usar o idioma do navegador e PT-BR quando não for possível lê-lo, sem alterar links, URLs ou conteúdo factual.
+- [ ] Inserir o toggle PT/EN no `nav-shell` existente, com estado acessível e layout responsivo.
+- [ ] Manter somente as regras CSS necessárias para o controle; não remover seções, animações ou o comportamento do hero.
+- [ ] Criar `README.en.md` com instruções técnicas equivalentes ao `README.md`, incluindo o link de volta para português; adicionar no README atual o link para inglês sem alterar instruções não relacionadas.
+- [ ] Rodar `node --test test/issue-19-i18n.test.mjs test/docs-hero-motion.test.mjs` e `cd docs && npm run build`.
+
+**Layout regression check:** comparar os seletores atuais de `.hero`, `.nav-shell`, `.features-section`, `.roadmap-section`, `.community-section`, `.faq-section` e os breakpoints móveis antes/depois; o único acréscimo visual permitido é o toggle no header.
+
+## Task 5 — Verificação integrada e inspeção visual
+
+**Files:** nenhum novo; revisar todos os arquivos alterados e os artefatos gerados localmente.
+
+- [ ] Rodar a suíte completa com `npm test` na raiz do worktree.
+- [ ] Rodar `cd mac && swift build` e `cd ../docs && npm run build` a partir da sequência correta, registrando qualquer falha separadamente por superfície.
+- [ ] Rodar `git diff --check` e revisar `git diff --stat`/`git diff` para confirmar que não há arquivos da PR #20 copiados por substituição nem mudanças fora do escopo.
+- [ ] Validar no browser real o PWA em navegador PT e não-PT: idioma inicial ao abrir, login, reload, recents, modal, toast, OBS, banner de atualização e viewport móvel com safe area/teclado.
+- [ ] Validar no macOS a troca em `Conectar`, atualização imediata de `Slots`/`Conectar`/menu bar, relançamento e preservação visual da janela/sidebar/semáforos.
+- [ ] Validar a landing em desktop e viewport móvel nos dois idiomas, incluindo toggle, links, FAQ, roadmap e persistência.
+- [ ] Se houver falha visual, corrigir apenas a superfície afetada e repetir os testes correspondentes e a suíte completa antes de reportar o resultado.
+- [ ] Entregar relatório final com arquivos alterados, testes executados e limites da validação; não fazer commit, push, merge, release ou deploy.
+
+## Self-review against the spec
+
+- O plano cobre PWA/APK, macOS, landing e README, os quatro critérios de superfície da spec.
+- A detecção automática do PWA/APK, a escolha persistente do macOS/landing e a atualização dos textos estão explicitamente implementadas e testadas.
+- A tradução inclui estados dinâmicos, erros, confirmações, toasts, OBS, update banner e acessibilidade.
+- Os contratos de layout e a proibição de substituir a PR #20 estão repetidos como restrições operacionais e verificações.
+- A verificação separa testes/build estáticos da inspeção visual real, como exige a spec.
+- O plano não inclui commit, push, merge, release ou deploy sem autorização.

--- a/docs/superpowers/specs/2026-08-28-dokke-issue-19-i18n-design.md
+++ b/docs/superpowers/specs/2026-08-28-dokke-issue-19-i18n-design.md
@@ -1,0 +1,192 @@
+# Dokke #19 — suporte a inglês e detecção de idioma
+
+## Status
+
+Implementada na branch isolada; integração ainda depende de autorização explícita.
+
+## Contexto
+
+A issue [#19](https://github.com/felipenalves/Dokke/issues/19) pede uma forma de
+escolher o idioma e solicita inglês para quem não entende português. A PR #20
+do autor da issue implementa uma primeira versão, mas foi aberta sobre um
+`main` antigo e não pode ser aplicada por substituição de arquivos: ela remove
+ou regride contratos visuais que já existem no `develop`.
+
+Serão reaproveitados somente os insights da PR:
+
+- dicionários explícitos para `pt-BR` e `en`;
+- detecção inicial pelo idioma do dispositivo/navegador;
+- toggle PT/EN na landing.
+
+## Objetivos
+
+- Disponibilizar inglês em toda a interface funcional do Dokke.
+- Manter português brasileiro como idioma padrão do produto.
+- Detectar automaticamente o idioma do dispositivo/navegador no PWA e APK.
+- Permitir escolha manual e persistente do idioma no app macOS e na landing.
+- Traduzir textos estáticos, estados dinâmicos, mensagens de erro,
+  confirmações, ações e rótulos de acessibilidade.
+- Preservar o layout, os gestos, a autenticação, a sincronização e os contratos
+  visuais atuais do `develop`.
+
+## Escopo
+
+### Idiomas e precedência
+
+Os únicos idiomas suportados nesta etapa são:
+
+- `pt-BR`: Português (Brasil);
+- `en`: English.
+
+A escolha inicial segue esta ordem:
+
+1. idioma do navegador no PWA/APK/landing ou idioma preferido do sistema no macOS;
+2. `pt-BR` quando o ambiente não puder ser lido.
+
+Qualquer idioma que não comece por `pt` cai em inglês na detecção automática.
+O PWA/APK não exibe seletor manual: a detecção é refeita ao abrir a interface.
+O app macOS e a landing mantêm suas escolhas manuais locais, iniciando pela
+detecção automática quando ainda não há preferência salva. Não será criada
+sincronização de idioma no servidor.
+
+### PWA e APK
+
+O APK continua usando a mesma interface web; portanto, a tradução do cliente
+Android vem do PWA. A camada nativa Android só entra no escopo se a auditoria
+encontrar texto visível fora da WebView.
+
+O `public/index.html` terá:
+
+- dicionário PT/EN com as mesmas chaves nos dois idiomas;
+- função de detecção baseada em `navigator.language`;
+- atualização de `document.documentElement.lang`;
+- nenhum controle manual de idioma no shell pré-login ou autenticado;
+- o APK reaproveita a mesma detecção porque carrega a interface web na WebView;
+- atualização sem recarregar a página de:
+  - login e erros de autenticação;
+  - dock, apps abertos, estados online/offline e limites;
+  - modal de fixar, confirmação de remoção e toasts;
+  - drawer do OBS, cenas, gravação, live e confirmação de encerramento;
+  - banner de atualização e suas ações;
+  - `aria-label`, `aria-labelledby`, títulos e rótulos de controles.
+
+As traduções não receberão nomes de apps, URLs ou mensagens vindas do servidor
+como HTML. Valores dinâmicos serão interpolados como texto; quando houver
+ênfase visual, a marcação ficará no template, não dentro do dicionário.
+
+### App macOS
+
+O macOS terá uma preferência explícita persistida em `UserDefaults`, com duas
+opções visíveis: `Português` e `English`. A detecção do idioma do sistema só
+define o valor inicial quando ainda não existe uma escolha salva.
+
+Implementação prevista:
+
+- criar um `LanguageStore` observável, injetado no ambiente do app;
+- substituir o `I18n` baseado somente em `Locale.preferredLanguages` por
+  traduções dependentes do valor selecionado;
+- adicionar o `Picker` de idioma na tela existente de `Conectar`, sem criar uma
+  nova navegação ou redesenhar a sidebar;
+- fazer todas as views (`Slots`, `Conectar`, picker, dock, menu bar, atualização
+  e diálogos) reagirem à troca imediatamente;
+- manter mensagens de erro e textos técnicos traduzidos, com nomes de apps,
+  URLs, PINs e números fora do dicionário.
+
+Não será usado `NSLocalizedString` nem catálogo de localização nesta etapa:
+o produto tem apenas dois idiomas, as strings já são pequenas e o código atual
+é SwiftUI sem infraestrutura de recursos localizada.
+
+### Landing/docs e README
+
+Na landing em `docs/`:
+
+- manter a estrutura e o CSS visual atuais;
+- detectar o idioma pelo navegador usando `navigator.language` quando não houver
+  preferência salva;
+- adicionar um toggle PT/EN no header existente e persistir a escolha local;
+- traduzir a cópia da página, textos de navegação, FAQ, roadmap e labels;
+- manter os links e o conteúdo factual sincronizados entre os idiomas;
+- garantir que o toggle não estoure o header em viewport móvel.
+
+No repositório:
+
+- manter `README.md` em português;
+- adicionar `README.en.md` em inglês;
+- adicionar links de troca entre os dois READMEs;
+- não alterar instruções técnicas ou prometer suporte que não exista.
+
+## Contrato de layout
+
+A mudança de idioma não é uma oportunidade para refazer a interface.
+
+- O grid, paginação, safe area, gesto, cards, drawer e modal do PWA permanecem
+  com a geometria atual.
+- A detecção automática não cria área reservada nem altera o cartão de conexão;
+  safe area, teclado Android e viewport móvel continuam com a geometria atual.
+- A sidebar, a largura da janela, os semáforos e o canvas do macOS não mudam.
+  O `Picker` entra como uma linha na tela `Conectar`.
+- O header da landing recebe somente o toggle; nenhuma seção ou animação atual
+  será removida para acomodá-lo.
+
+## Critérios de aceitação
+
+- [ ] O PWA/APK detecta `pt-BR` em dispositivo/navegador configurado em português.
+- [ ] O PWA/APK detecta inglês em dispositivo/navegador configurado em outro idioma.
+- [ ] O PWA/APK não exibe seletor manual e refaz a detecção ao abrir.
+- [ ] Todos os fluxos funcionais do PWA têm texto nos dois idiomas, inclusive
+      erros, confirmações, toasts e acessibilidade.
+- [ ] O macOS oferece `Português` e `English` na tela `Conectar`.
+- [ ] A escolha do macOS sobrevive ao relançamento do app e atualiza as views
+      observáveis sem reiniciar.
+- [ ] A landing detecta PT/EN ao abrir, oferece seletor manual persistente e mantém layout responsivo.
+- [ ] README em português e inglês têm links de troca e instruções coerentes.
+- [ ] Nenhuma mudança altera autenticação, API, WebSocket, ordenação, limites,
+      abertura de apps, OBS ou comportamento de websites.
+
+## Testes e verificação
+
+### Testes automatizados
+
+Adicionar cobertura focada em `test/issue-19-i18n.test.mjs` para:
+
+- paridade de chaves entre os dicionários PT/EN do PWA;
+- detecção automática, fallback de idioma e atualização do atributo `lang`;
+- ausência de controle manual de idioma no PWA/APK;
+- ausência de textos funcionais críticos fora do caminho de tradução;
+- paridade de chaves da landing;
+- existência do `LanguageStore`, do `Picker` e da persistência no macOS;
+- detecção automática, toggle e persistência manual na landing;
+- preservação dos seletores/contratos visuais atuais.
+
+Executar, na branch de implementação:
+
+```sh
+npm test
+cd mac && swift build
+cd ../docs && npm run build
+git diff --check
+```
+
+### Verificação manual
+
+Depois dos testes de código, validar no browser real o PWA e a landing em PT e EN,
+incluindo abertura, login, modal, recents, OBS, banner e viewport móvel com safe
+area. Na landing, validar a detecção, a troca manual, a persistência e o header
+responsivo. No macOS, validar a troca, relançamento e menu bar. A build estática
+e os testes de contrato não substituem essa inspeção visual.
+
+## Fora do escopo
+
+- tradução do servidor, API, logs internos ou nomes de apps do usuário;
+- novos idiomas além de PT-BR e inglês;
+- sincronização de idioma entre dispositivos;
+- redesign ou substituição integral dos arquivos atuais pela PR #20;
+- merge/aprovação da PR #20;
+- commit, push, release ou deploy sem autorização separada.
+
+## Resultado esperado
+
+Issue #19 atendida com uma implementação integrada ao `develop`: inglês
+detectado automaticamente no PWA/APK, selecionável e persistente no macOS e
+landing, sem perder as alterações visuais e funcionais que já foram construídas
+depois da base usada pela PR comunitária.

--- a/mac/Sources/AppPickerSheet.swift
+++ b/mac/Sources/AppPickerSheet.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct AppPickerSheet: View {
   @EnvironmentObject private var store: DockStore
+  @EnvironmentObject private var languageStore: LanguageStore
   @Environment(\.dismiss) private var dismiss
   let insertAt: Int?
   @State private var search = ""
@@ -44,14 +45,14 @@ struct AppPickerSheet: View {
     ZStack {
       VStack(spacing: 0) {
       HStack(spacing: 10) {
-        Picker("Tipo de peça", selection: $selectedTab) {
-          Text("Apps").tag("Apps")
-          Text("Website Links").tag("Website Links")
+        Picker(I18n.text("picker.type", language: languageStore.selected), selection: $selectedTab) {
+          Text(I18n.text("picker.apps", language: languageStore.selected)).tag("Apps")
+          Text(I18n.text("picker.websites", language: languageStore.selected)).tag("Website Links")
         }
         .labelsHidden()
         .pickerStyle(.segmented)
         .frame(maxWidth: .infinity)
-        .accessibilityLabel("Tipo de peça")
+        .accessibilityLabel(I18n.text("picker.type", language: languageStore.selected))
 
         Button { dismiss() } label: {
           Image(systemName: "xmark")
@@ -61,7 +62,7 @@ struct AppPickerSheet: View {
             .background(Color.white.opacity(0.10), in: Circle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Fechar")
+        .accessibilityLabel(I18n.text("picker.close", language: languageStore.selected))
       }
       .padding(.horizontal, 16)
       .padding(.top, 16)
@@ -75,7 +76,7 @@ struct AppPickerSheet: View {
           .foregroundStyle(.white.opacity(0.92))
           .frame(width: 42, height: 42)
           .background(Color.white.opacity(0.10), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        Text(selectedTab == "Apps" ? "Adicionar Apps" : "Adicionar links ao dock")
+        Text(I18n.text(selectedTab == "Apps" ? "picker.addApps" : "picker.addLinks", language: languageStore.selected))
           .font(.system(size: 18, weight: .bold))
           .lineLimit(1)
         Spacer(minLength: 0)
@@ -89,13 +90,13 @@ struct AppPickerSheet: View {
           Image(systemName: "chevron.down")
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(.secondary)
-          Text("App Library")
+          Text(I18n.text("picker.library", language: languageStore.selected))
             .font(.system(size: 16, weight: .semibold))
           Spacer(minLength: 12)
           HStack(spacing: 7) {
             Image(systemName: "magnifyingglass")
               .foregroundStyle(.secondary)
-            TextField("Buscar apps...", text: $search)
+            TextField(I18n.text("picker.search", language: languageStore.selected), text: $search)
               .textFieldStyle(.plain)
             if !search.isEmpty {
               Button { search = "" } label: {
@@ -117,7 +118,7 @@ struct AppPickerSheet: View {
         .padding(.bottom, 10)
 
         if store.isPinnedLimitReached {
-          Text("Limite de 5 páginas atingido. Remova uma peça para adicionar outra.")
+          Text(I18n.text("picker.limit", language: languageStore.selected))
             .font(.caption)
             .foregroundStyle(.orange)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -126,16 +127,16 @@ struct AppPickerSheet: View {
         }
 
         if store.installedLoading && !store.installedReady {
-          ProgressView("Carregando apps…")
+          ProgressView(I18n.text("picker.loading", language: languageStore.selected))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if store.loading && !store.installedReady {
-          ProgressView("Carregando apps…")
+          ProgressView(I18n.text("picker.loading", language: languageStore.selected))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if filteredApps.isEmpty {
           ContentUnavailableView(
-            search.isEmpty ? "Nenhum app encontrado" : "Sem resultados",
+            search.isEmpty ? I18n.text("picker.none", language: languageStore.selected) : I18n.text("picker.noResults", language: languageStore.selected),
             systemImage: "app.dashed",
-            description: Text(search.isEmpty ? "O servidor não retornou apps instalados." : "Tente uma busca diferente.")
+            description: Text(search.isEmpty ? I18n.text("picker.serverEmpty", language: languageStore.selected) : I18n.text("picker.searchDifferent", language: languageStore.selected))
           )
         } else {
           ScrollView {
@@ -169,9 +170,9 @@ struct AppPickerSheet: View {
       HStack(spacing: 8) {
         Image(systemName: "globe")
           .foregroundStyle(.secondary)
-        TextField("https://exemplo.com", text: $websiteURL)
+        TextField(I18n.text("picker.url", language: languageStore.selected), text: $websiteURL)
           .textFieldStyle(.plain)
-        Button("Adicionar") {
+        Button(I18n.text("picker.add", language: languageStore.selected)) {
           beginWebsiteAdd(url: websiteURL)
         }
         .buttonStyle(.borderedProminent)
@@ -190,7 +191,7 @@ struct AppPickerSheet: View {
       )
 
       if store.isPinnedLimitReached {
-        Text("Limite de 5 páginas atingido. Remova uma peça para adicionar outra.")
+      Text(I18n.text("picker.limit", language: languageStore.selected))
           .font(.caption)
           .foregroundStyle(.orange)
       }
@@ -200,7 +201,7 @@ struct AppPickerSheet: View {
           .foregroundStyle(.red)
       }
 
-      Text("Sugestões")
+      Text(I18n.text("picker.suggestions", language: languageStore.selected))
         .font(.headline)
         .padding(.top, 4)
 
@@ -234,11 +235,11 @@ struct AppPickerSheet: View {
       Spacer(minLength: 8)
 
       if store.pieces.contains(where: { $0.type == .website && $0.url == suggestion.1 + "/" }) {
-        Label("Adicionado", systemImage: "checkmark.circle.fill")
+        Label(I18n.text("picker.added", language: languageStore.selected), systemImage: "checkmark.circle.fill")
           .font(.caption)
           .foregroundStyle(.green)
       } else {
-        Button("Adicionar") {
+        Button(I18n.text("picker.add", language: languageStore.selected)) {
           beginWebsiteAdd(url: suggestion.1, suggestedTitle: suggestion.0)
         }
         .buttonStyle(.borderedProminent)
@@ -313,12 +314,12 @@ struct AppPickerSheet: View {
       .frame(width: 48, height: 48)
       .background(Color.white.opacity(0.92), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
 
-      Text("Vamos dar um nome curto para o seu weblink.")
+      Text(I18n.text("picker.nameHint", language: languageStore.selected))
         .font(.system(size: 19, weight: .bold))
         .multilineTextAlignment(.center)
         .lineLimit(2)
 
-      TextField("Nome do site", text: $pendingWebsiteTitle)
+      TextField(I18n.text("picker.siteName", language: languageStore.selected), text: $pendingWebsiteTitle)
         .textFieldStyle(.roundedBorder)
         .onSubmit { confirmWebsiteAdd() }
 
@@ -330,10 +331,10 @@ struct AppPickerSheet: View {
       }
 
       HStack(spacing: 12) {
-        Button("Cancelar") { cancelWebsiteAdd() }
+        Button(I18n.text("confirm.cancel", language: languageStore.selected)) { cancelWebsiteAdd() }
           .buttonStyle(.bordered)
           .controlSize(.small)
-        Button("Adicionar") { confirmWebsiteAdd() }
+        Button(I18n.text("picker.add", language: languageStore.selected)) { confirmWebsiteAdd() }
           .buttonStyle(.borderedProminent)
           .controlSize(.small)
           .disabled(pendingWebsiteTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.busyName != nil)
@@ -382,9 +383,9 @@ struct AppPickerSheet: View {
         Image(systemName: "checkmark.circle.fill")
           .font(.system(size: 18, weight: .semibold))
           .foregroundStyle(.green)
-          .accessibilityLabel("Adicionado")
+          .accessibilityLabel(I18n.text("picker.added", language: languageStore.selected))
       } else {
-        Button("Adicionar") {
+        Button(I18n.text("picker.add", language: languageStore.selected)) {
           Task {
             if let insertAt {
               await store.pin(app.name, at: insertAt)

--- a/mac/Sources/ContentView.swift
+++ b/mac/Sources/ContentView.swift
@@ -20,6 +20,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
 struct ContentView: View {
   @EnvironmentObject private var store: DockStore
   @EnvironmentObject private var updater: DokkeUpdateManager
+  @EnvironmentObject private var languageStore: LanguageStore
   @State private var selection: SidebarItem? = .apps
   @State private var isSidebarVisible = true
   @State private var hoveredSidebarItem: SidebarItem?
@@ -91,7 +92,7 @@ struct ContentView: View {
         .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .accessibilityLabel(isSidebarVisible ? "Ocultar sidebar" : "Mostrar sidebar")
+    .accessibilityLabel(I18n.text(isSidebarVisible ? "sidebar.hide" : "sidebar.show", language: languageStore.selected))
   }
 
   private var customTrafficLights: some View {
@@ -137,7 +138,7 @@ struct ContentView: View {
             Image(systemName: item.icon)
               .font(.system(size: 12, weight: .medium))
               .frame(width: 14, height: 14)
-            Text(item.rawValue)
+            Text(I18n.text(item == .apps ? "sidebar.slots" : "sidebar.connect", language: languageStore.selected))
               .font(.system(size: 13, weight: .medium))
             Spacer(minLength: 0)
           }
@@ -158,8 +159,8 @@ struct ContentView: View {
             hoveredSidebarItem = nil
           }
         }
-        .accessibilityLabel(item.rawValue)
-        .accessibilityValue(selection == item ? "Selecionado" : "")
+        .accessibilityLabel(I18n.text(item == .apps ? "sidebar.slots" : "sidebar.connect", language: languageStore.selected))
+        .accessibilityValue(selection == item ? I18n.text("sidebar.selected", language: languageStore.selected) : "")
       }
       Spacer()
     }
@@ -318,6 +319,7 @@ struct AboutView: View {
   @EnvironmentObject private var store: DockStore
   @EnvironmentObject private var server: ServerManager
   @EnvironmentObject private var updater: DokkeUpdateManager
+  @EnvironmentObject private var languageStore: LanguageStore
   @State private var showingReleaseNotes = false
   @State private var showingResetPinConfirmation = false
   private let aboutContentMaxWidth: CGFloat = 980
@@ -325,16 +327,32 @@ struct AboutView: View {
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 20) {
+        HStack {
+          Text(I18n.text("aria.language", language: languageStore.selected))
+            .font(.subheadline.weight(.semibold))
+          Spacer()
+          Picker("Idioma", selection: Binding(
+            get: { languageStore.selected },
+            set: { languageStore.select($0) }
+          )) {
+            ForEach(DokkeLanguage.allCases) { language in
+              Text(language.displayName).tag(language)
+            }
+          }
+          .pickerStyle(.menu)
+          .accessibilityLabel("Idioma")
+        }
+
         VStack(alignment: .leading, spacing: 4) {
-          Text("Conectar outro dispositivo")
+          Text(I18n.text("connect.title", language: languageStore.selected))
             .font(.title.bold())
-          Text("Use o código abaixo no app ou navegador que você quer conectar ao Dokke.")
+          Text(I18n.text("connect.description", language: languageStore.selected))
             .font(.subheadline)
             .foregroundStyle(.secondary)
         }
 
         VStack(spacing: 16) {
-          Text("Código de acesso")
+          Text(I18n.text("connect.accessCode", language: languageStore.selected))
             .font(.headline)
           AccessCodeView(code: store.pinCode) {
             showingResetPinConfirmation = true
@@ -353,7 +371,7 @@ struct AboutView: View {
         )
 
         VStack(alignment: .leading, spacing: 16) {
-          Text("Abrir em outro dispositivo")
+          Text(I18n.text("connect.openOther", language: languageStore.selected))
             .font(.headline)
           if let ip = ServerManager.lanIPv4() {
             let localURL = "http://\(ip):3000"
@@ -362,7 +380,7 @@ struct AboutView: View {
                 .frame(width: 112, height: 112)
 
               VStack(alignment: .leading, spacing: 10) {
-                Text("Escaneie ou abra este endereço")
+                Text(I18n.text("connect.scan", language: languageStore.selected))
                   .font(.caption.weight(.semibold))
                 Text(localURL)
                   .font(.system(size: 14, weight: .semibold, design: .monospaced))
@@ -374,7 +392,7 @@ struct AboutView: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(localURL, forType: .string)
                   } label: {
-                    Label("Copiar URL", systemImage: "doc.on.doc")
+                    Label(I18n.text("connect.copyURL", language: languageStore.selected), systemImage: "doc.on.doc")
                   }
                   .buttonStyle(.bordered)
                   Button {
@@ -382,17 +400,17 @@ struct AboutView: View {
                       NSWorkspace.shared.open(url)
                     }
                   } label: {
-                    Label("Abrir", systemImage: "arrow.up.right.square")
+                    Label(I18n.text("connect.open", language: languageStore.selected), systemImage: "arrow.up.right.square")
                   }
                   .buttonStyle(.bordered)
                 }
               }
             }
-            Text("O Mac e o dispositivo precisam estar na mesma rede. Para iPhone/iPad, use uma URL HTTPS do túnel antes de adicionar à Tela de Início.")
+            Text(I18n.text("connect.network", language: languageStore.selected))
               .font(.caption)
               .foregroundStyle(.secondary)
           } else {
-            Text("Sem IP de rede detectado (offline?)")
+            Text(I18n.text("connect.noIP", language: languageStore.selected))
               .font(.caption)
               .foregroundStyle(.secondary)
           }
@@ -409,11 +427,11 @@ struct AboutView: View {
             Circle()
               .fill(store.online ? Color.green : Color.red.opacity(0.85))
               .frame(width: 9, height: 9)
-            Text(store.online ? "Servidor online" : "Servidor offline")
+            Text(I18n.text(store.online ? "connect.online" : "connect.offline", language: languageStore.selected))
               .font(.subheadline.weight(.semibold))
           }
-          Text("\(store.devices) dispositivos")
-          Text("\(store.pinned.count) fixados")
+          Text(I18n.text("connect.devices", language: languageStore.selected, ["count": "\(store.devices)"]))
+          Text(I18n.text("connect.pinned", language: languageStore.selected, ["count": "\(store.pinned.count)"]))
           Spacer()
         }
         .font(.caption)
@@ -427,7 +445,7 @@ struct AboutView: View {
 
         VStack(alignment: .leading, spacing: 8) {
           HStack {
-            Text("Atualizações")
+            Text(I18n.text("updates.title", language: languageStore.selected))
               .font(.subheadline.weight(.semibold))
             Spacer()
             if updater.state == .checking {
@@ -436,16 +454,16 @@ struct AboutView: View {
           }
           if let release = updater.release {
             HStack(spacing: 8) {
-              Label("Nova versão \(release.tag)", systemImage: "arrow.down.circle.fill")
+              Label(I18n.text("updates.new", language: languageStore.selected, ["version": release.tag]), systemImage: "arrow.down.circle.fill")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.orange)
               Spacer()
-              Button("Mudanças") {
+              Button(I18n.text("updates.changes", language: languageStore.selected)) {
                 showingReleaseNotes = true
               }
               .buttonStyle(.bordered)
               .controlSize(.small)
-              Button("Baixar e instalar") {
+              Button(I18n.text("updates.install", language: languageStore.selected)) {
                 Task { await updater.downloadAndInstall() }
               }
               .buttonStyle(.borderedProminent)
@@ -454,11 +472,11 @@ struct AboutView: View {
             }
           } else {
             HStack {
-              Text("Versão instalada: \(updater.currentVersion)")
+              Text(I18n.text("updates.installed", language: languageStore.selected, ["version": updater.currentVersion]))
                 .font(.caption)
                 .foregroundStyle(.secondary)
               Spacer()
-              Button("Verificar atualizações") {
+              Button(I18n.text("updates.check", language: languageStore.selected)) {
                 Task { await updater.check() }
               }
               .buttonStyle(.bordered)
@@ -466,7 +484,7 @@ struct AboutView: View {
               .disabled(updater.isBusy)
             }
           }
-          if let message = updater.statusMessage {
+          if let message = updater.statusMessage(language: languageStore.selected) {
             if updater.release == nil {
               Text(message)
                 .font(.caption)
@@ -491,13 +509,13 @@ struct AboutView: View {
       // A aba pode ser aberta depois do refresh inicial do store.
       await store.loadPin()
     }
-    .confirmationDialog("Gerar novo código?", isPresented: $showingResetPinConfirmation, titleVisibility: .visible) {
-      Button("Gerar novo código", role: .destructive) {
+    .confirmationDialog(I18n.text("confirm.newCode", language: languageStore.selected), isPresented: $showingResetPinConfirmation, titleVisibility: .visible) {
+      Button(I18n.text("confirm.newCodeAction", language: languageStore.selected), role: .destructive) {
         Task { await store.resetPin() }
       }
-      Button("Cancelar", role: .cancel) {}
+      Button(I18n.text("confirm.cancel", language: languageStore.selected), role: .cancel) {}
     } message: {
-      Text("Os dispositivos conectados precisarão digitar o novo código.")
+      Text(I18n.text("confirm.newCodeMessage", language: languageStore.selected))
     }
     .sheet(isPresented: $showingReleaseNotes) {
       if let release = updater.release {
@@ -508,6 +526,7 @@ struct AboutView: View {
 }
 
 private struct AccessCodeView: View {
+  @EnvironmentObject private var languageStore: LanguageStore
   let code: String?
   let onRegenerate: () -> Void
 
@@ -529,10 +548,10 @@ private struct AccessCodeView: View {
             .clipShape(RoundedRectangle(cornerRadius: 16))
         }
       }
-      Text("Digite este código no dispositivo conectado")
+      Text(I18n.text("accessCode.instruction", language: languageStore.selected))
         .font(.subheadline.weight(.semibold))
         .foregroundStyle(.secondary)
-      Button("Gerar novo código", action: onRegenerate)
+      Button(I18n.text("confirm.newCodeAction", language: languageStore.selected), action: onRegenerate)
         .buttonStyle(.link)
     }
     .frame(maxWidth: .infinity)
@@ -575,6 +594,7 @@ private struct QRCodeView: View {
 
 private struct ReleaseNotesView: View {
   @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject private var languageStore: LanguageStore
   let release: DokkeRelease
   private let renderedNotes: AttributedString
 
@@ -587,13 +607,13 @@ private struct ReleaseNotesView: View {
     VStack(alignment: .leading, spacing: 16) {
       HStack {
         VStack(alignment: .leading, spacing: 4) {
-          Text("O que mudou")
+          Text(I18n.text("release.changed", language: languageStore.selected))
             .font(.title2.bold())
           Text("Dokke \(release.tag)")
             .foregroundStyle(.secondary)
         }
         Spacer()
-        Button("Fechar") {
+        Button(I18n.text("release.close", language: languageStore.selected)) {
           dismiss()
         }
         .buttonStyle(.bordered)
@@ -615,6 +635,7 @@ struct MenuBarView: View {
   @EnvironmentObject private var store: DockStore
   @EnvironmentObject private var server: ServerManager
   @EnvironmentObject private var updater: DokkeUpdateManager
+  @EnvironmentObject private var languageStore: LanguageStore
 
   private var appVersion: String {
     (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0.2.7"
@@ -623,8 +644,8 @@ struct MenuBarView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       HStack(spacing: 10) {
-        Text("Dispositivo: \(store.devices)")
-        Text("Fixados: \(store.pinned.count)")
+        Text(I18n.text("menu.device", language: languageStore.selected, ["count": "\(store.devices)"]))
+        Text(I18n.text("menu.pinned", language: languageStore.selected, ["count": "\(store.pinned.count)"]))
       }
         .font(.caption)
         .foregroundStyle(.secondary)
@@ -637,28 +658,28 @@ struct MenuBarView: View {
       Button {
         openWindow(id: "main")
       } label: {
-        Label("Abrir Dokke", systemImage: "macwindow")
+        Label(I18n.text("menu.open", language: languageStore.selected), systemImage: "macwindow")
       }
       Button {
         Task { await store.refreshAll() }
       } label: {
-        Label("Sincronizar agora", systemImage: "arrow.triangle.2.circlepath")
+        Label(I18n.text("menu.sync", language: languageStore.selected), systemImage: "arrow.triangle.2.circlepath")
       }
       if let release = updater.release {
         Divider()
-        Text("Atualização \(release.tag) disponível")
+        Text(I18n.text("menu.update", language: languageStore.selected, ["version": release.tag]))
           .font(.caption.weight(.semibold))
         Button {
           Task { await updater.downloadAndInstall() }
         } label: {
-          Label("Baixar e instalar", systemImage: "arrow.down.circle")
+          Label(I18n.text("updates.install", language: languageStore.selected), systemImage: "arrow.down.circle")
         }
         .disabled(updater.isBusy)
       } else {
         Button {
           Task { await updater.check() }
         } label: {
-          Label("Verificar atualizações", systemImage: "arrow.down.circle")
+          Label(I18n.text("updates.check", language: languageStore.selected), systemImage: "arrow.down.circle")
         }
         .disabled(updater.isBusy)
       }
@@ -667,12 +688,12 @@ struct MenuBarView: View {
         server.stop()
         NSApplication.shared.terminate(nil)
       } label: {
-        Label("Sair", systemImage: "power")
+        Label(I18n.text("menu.quit", language: languageStore.selected), systemImage: "power")
       }
       Divider()
       Button {} label: {
         HStack(alignment: .center, spacing: 0) {
-          Text("Versão \(appVersion)")
+          Text(I18n.text("menu.version", language: languageStore.selected, ["version": appVersion]))
             .font(.caption2)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: true, vertical: false)

--- a/mac/Sources/DockGridView.swift
+++ b/mac/Sources/DockGridView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DockGridView: View {
   @EnvironmentObject private var store: DockStore
+  @EnvironmentObject private var languageStore: LanguageStore
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var showPicker = false
   @State private var draggedItem: String?
@@ -87,7 +88,7 @@ struct DockGridView: View {
             HStack(spacing: 6) {
               Image(systemName: "arrow.up.left.and.arrow.down.right")
                 .font(.system(size: 11, weight: .medium))
-              Text("Arraste para mover um ícone de posição.")
+              Text(I18n.text("grid.drag", language: languageStore.selected))
                 .font(.system(size: 12))
             }
             .foregroundStyle(.white.opacity(0.85))
@@ -174,8 +175,8 @@ struct DockGridView: View {
             .frame(width: 7, height: 7)
         }
         .buttonStyle(.plain)
-        .help("Página \(index + 1)")
-        .accessibilityLabel("Página \(index + 1)")
+        .help(I18n.text("grid.page", language: languageStore.selected, ["page": "\(index + 1)"]))
+        .accessibilityLabel(I18n.text("grid.page", language: languageStore.selected, ["page": "\(index + 1)"]))
       }
     }
     .frame(maxWidth: .infinity)
@@ -280,7 +281,7 @@ struct DockGridView: View {
         isReordering.toggle()
       }
     } label: {
-        Text(isReordering ? "Concluir" : "Reorganizar apps")
+        Text(I18n.text(isReordering ? "grid.reorder.done" : "grid.reorder", language: languageStore.selected))
         .font(.system(size: 13, weight: .semibold))
         .foregroundStyle(isReordering ? Color.white : Color.white.opacity(0.9))
         .padding(.horizontal, 20)
@@ -289,7 +290,7 @@ struct DockGridView: View {
         .clipShape(Capsule())
     }
     .buttonStyle(.plain)
-    .help(isReordering ? "Concluir reorganização" : "Reorganizar apps")
+    .help(I18n.text(isReordering ? "grid.reorderHelp" : "grid.reorder", language: languageStore.selected))
   }
 
   @ViewBuilder
@@ -301,19 +302,19 @@ struct DockGridView: View {
     if isReordering {
       addSlot
         .onDrop(of: [.text], delegate: DropDelegate(position: index, store: store, reduceMotion: reduceMotion, draggedItem: $draggedItem, draftPositions: $draftPositions))
-        .help("Mover app para a posição \(index + 1)")
+        .help(I18n.text("grid.move", language: languageStore.selected, ["position": "\(index + 1)"]))
     } else {
       addSlot
         .disabled(store.isPinnedLimitReached)
-        .help(store.isPinnedLimitReached ? "Limite de 5 páginas atingido" : "Adicionar app nesta posição")
+        .help(store.isPinnedLimitReached ? I18n.text("grid.limit", language: languageStore.selected) : I18n.text("grid.addHere", language: languageStore.selected))
     }
   }
 
   private var offlineView: some View {
     ContentUnavailableView(
-      "Servidor Offline",
+      I18n.text("grid.offline", language: languageStore.selected),
       systemImage: "wifi.slash",
-      description: Text("Inicie o servidor Dokke e verifique a conexão na aba Conectar.")
+      description: Text(I18n.text("grid.offlineDescription", language: languageStore.selected))
     )
     .foregroundStyle(.white.opacity(0.85))
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -321,6 +322,7 @@ struct DockGridView: View {
 }
 
 private struct AddSlotButton: View {
+  @EnvironmentObject private var languageStore: LanguageStore
   let index: Int
   let size: CGFloat
   let action: () -> Void
@@ -345,7 +347,7 @@ private struct AddSlotButton: View {
           }
         }
 
-        Text(isHovered ? "Add" : " ")
+        Text(isHovered ? I18n.text("picker.add", language: languageStore.selected) : " ")
           .font(.system(size: 11, weight: .medium))
           .foregroundStyle(.white.opacity(0.78))
           .frame(height: 13)
@@ -354,8 +356,8 @@ private struct AddSlotButton: View {
     }
     .buttonStyle(.plain)
     .onHover { isHovered = $0 }
-    .help("Adicionar app na posição \(index + 1)")
-    .accessibilityLabel("Adicionar app na posição \(index + 1)")
+    .help(I18n.text("grid.add", language: languageStore.selected, ["position": "\(index + 1)"]))
+    .accessibilityLabel(I18n.text("grid.add", language: languageStore.selected, ["position": "\(index + 1)"]))
   }
 }
 

--- a/mac/Sources/DockIcon.swift
+++ b/mac/Sources/DockIcon.swift
@@ -448,6 +448,7 @@ struct WebsiteFaviconView: View {
 
 struct DockIcon: View {
   @EnvironmentObject private var store: DockStore
+  @EnvironmentObject private var languageStore: LanguageStore
   let piece: DockPiece
   let allowsRemoval: Bool
   var isReordering: Bool = false
@@ -517,7 +518,7 @@ struct DockIcon: View {
                 .frame(width: 22, height: 22)
                 .modifier(HoverControlGlassModifier(isInteractive: true))
 
-                Text("Remover")
+                Text(I18n.text("icon.remove", language: languageStore.selected))
                   .font(.system(size: 9, weight: .semibold))
                   .foregroundStyle(.white)
               }
@@ -526,8 +527,8 @@ struct DockIcon: View {
             .contentShape(Rectangle())
           }
           .buttonStyle(.plain)
-          .help(piece.type == .website ? "Remover site fixado" : "Remover app fixado")
-          .accessibilityLabel(piece.type == .website ? "Remover site fixado" : "Remover app fixado")
+          .help(I18n.text(piece.type == .website ? "icon.removeWebsite" : "icon.removeApp", language: languageStore.selected))
+          .accessibilityLabel(I18n.text(piece.type == .website ? "icon.removeWebsite" : "icon.removeApp", language: languageStore.selected))
           .frame(width: iconCardSize, height: iconCardSize)
           .zIndex(5)
         }
@@ -556,7 +557,7 @@ struct DockIcon: View {
               }
                 .frame(width: 22, height: 22)
                 .modifier(HoverControlGlassModifier(isInteractive: false))
-              Text("Mover")
+              Text(I18n.text("icon.move", language: languageStore.selected))
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.white)
             }
@@ -583,7 +584,7 @@ struct DockIcon: View {
       Task { await store.openWebsite(piece.id) }
     }
     .contextMenu {
-      Button("Remover do Dock") {
+      Button(I18n.text("icon.removeDock", language: languageStore.selected)) {
         Task { await store.unpin(name) }
       }
     }

--- a/mac/Sources/DokkeApp.swift
+++ b/mac/Sources/DokkeApp.swift
@@ -78,6 +78,7 @@ struct DokkeApp: App {
   @StateObject private var store = DockStore()
   @StateObject private var server = ServerManager()
   @StateObject private var updater = DokkeUpdateManager()
+  @StateObject private var languageStore = LanguageStore()
 
   var body: some Scene {
     Window("Dokke", id: "main") {
@@ -85,6 +86,7 @@ struct DokkeApp: App {
         .environmentObject(store)
         .environmentObject(server)
         .environmentObject(updater)
+        .environmentObject(languageStore)
         .background(WindowStyleConfigurator())
         .frame(minWidth: 840, idealWidth: 980, minHeight: 540, idealHeight: 628)
     }
@@ -97,6 +99,7 @@ struct DokkeApp: App {
         .environmentObject(store)
         .environmentObject(server)
         .environmentObject(updater)
+        .environmentObject(languageStore)
     } label: {
       MenuBarIcon()
         .accessibilityLabel("Dokke")

--- a/mac/Sources/DokkeUpdateManager.swift
+++ b/mac/Sources/DokkeUpdateManager.swift
@@ -45,13 +45,17 @@ final class DokkeUpdateManager: ObservableObject {
   }
 
   var statusMessage: String? {
+    statusMessage(language: DokkeLanguage(rawValue: UserDefaults.standard.string(forKey: LanguageStore.defaultsKey) ?? "") ?? .portuguese)
+  }
+
+  func statusMessage(language: DokkeLanguage) -> String? {
     switch state {
     case .idle: return nil
-    case .checking: return "Verificando atualizações..."
-    case .available: return "Nova versão disponível."
-    case .downloading: return "Baixando a atualização..."
-    case .installing: return "Instalando a atualização..."
-    case .upToDate: return "Você está na versão mais recente."
+    case .checking: return I18n.text("update.checking", language: language)
+    case .available: return I18n.text("update.available", language: language)
+    case .downloading: return I18n.text("update.downloading", language: language)
+    case .installing: return I18n.text("update.installing", language: language)
+    case .upToDate: return I18n.text("update.current", language: language)
     case .failed(let message): return message
     }
   }
@@ -67,7 +71,7 @@ final class DokkeUpdateManager: ObservableObject {
       request.setValue("Dokke/\(currentVersion)", forHTTPHeaderField: "User-Agent")
       let (data, response) = try await URLSession.shared.data(for: request)
       guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-        throw UpdateError.network("O GitHub não respondeu corretamente.")
+        throw UpdateError.network
       }
 
       let dto = try JSONDecoder().decode(GitHubReleaseDTO.self, from: data)
@@ -80,7 +84,7 @@ final class DokkeUpdateManager: ObservableObject {
       guard let asset = dto.assets.first(where: { $0.name == "Dokke-macOS.dmg" }),
             let digest = asset.digest?.replacingOccurrences(of: "sha256:", with: "")
       else {
-        throw UpdateError.invalidRelease("A release não contém um instalador macOS válido.")
+        throw UpdateError.invalidRelease
       }
 
       release = DokkeRelease(
@@ -109,7 +113,7 @@ final class DokkeUpdateManager: ObservableObject {
       let request = URLRequest(url: release.dmgURL)
       let (downloadedURL, response) = try await URLSession.shared.download(for: request)
       guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-        throw UpdateError.network("Não foi possível baixar a atualização.")
+        throw UpdateError.download
       }
 
       let dmgURL = workspace.appendingPathComponent("Dokke-macOS.dmg")
@@ -124,7 +128,7 @@ final class DokkeUpdateManager: ObservableObject {
 
       let sourceApp = mountPoint.appendingPathComponent("Dokke.app", isDirectory: true)
       guard fileManager.fileExists(atPath: sourceApp.path) else {
-        throw UpdateError.invalidRelease("O instalador não contém o Dokke.app.")
+        throw UpdateError.missingApp
       }
 
       let stagedApp = workspace.appendingPathComponent("Dokke.app", isDirectory: true)
@@ -134,10 +138,10 @@ final class DokkeUpdateManager: ObservableObject {
 
       let targetApp = Bundle.main.bundleURL.standardizedFileURL
       guard targetApp.lastPathComponent == "Dokke.app" else {
-        throw UpdateError.install("O Dokke precisa estar instalado como um aplicativo para ser atualizado.")
+        throw UpdateError.notInstalled
       }
       guard fileManager.isWritableFile(atPath: targetApp.deletingLastPathComponent().path) else {
-        throw UpdateError.install("Sem permissão para atualizar a pasta do Dokke. Mova o app para Aplicativos e tente novamente.")
+        throw UpdateError.permission
       }
 
       try scheduleReplacement(stagedApp: stagedApp, targetApp: targetApp, workspace: workspace)
@@ -168,7 +172,7 @@ final class DokkeUpdateManager: ObservableObject {
       .map { String(format: "%02x", $0) }
       .joined()
     guard digest.caseInsensitiveCompare(expected) == .orderedSame else {
-      throw UpdateError.invalidRelease("A assinatura do download não confere com a release.")
+      throw UpdateError.checksum
     }
   }
 
@@ -178,7 +182,7 @@ final class DokkeUpdateManager: ObservableObject {
           let entities = plist["system-entities"] as? [[String: Any]],
           let mountPath = entities.compactMap({ $0["mount-point"] as? String }).first
     else {
-      throw UpdateError.install("Não foi possível montar o instalador.")
+      throw UpdateError.mount
     }
     return URL(fileURLWithPath: mountPath, isDirectory: true)
   }
@@ -199,7 +203,7 @@ final class DokkeUpdateManager: ObservableObject {
     let output = pipe.fileHandleForReading.readDataToEndOfFile()
     guard process.terminationStatus == 0 else {
       let message = String(data: output, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-      throw UpdateError.process(message?.isEmpty == false ? message! : "Falha ao executar o instalador.")
+      throw UpdateError.process(message?.isEmpty == false ? message! : nil)
     }
     return output
   }
@@ -261,14 +265,30 @@ private struct GitHubAssetDTO: Decodable {
 }
 
 private enum UpdateError: LocalizedError {
-  case network(String)
-  case invalidRelease(String)
-  case install(String)
-  case process(String)
+  case network
+  case invalidRelease
+  case download
+  case missingApp
+  case notInstalled
+  case permission
+  case checksum
+  case mount
+  case process(String?)
 
   var errorDescription: String? {
+    let language = DokkeLanguage(rawValue: UserDefaults.standard.string(forKey: LanguageStore.defaultsKey) ?? "") ?? .portuguese
     switch self {
-    case .network(let message), .invalidRelease(let message), .install(let message), .process(let message): return message
+    case .network: return I18n.text("update.errorNetwork", language: language)
+    case .invalidRelease: return I18n.text("update.errorInvalidRelease", language: language)
+    case .download: return I18n.text("update.errorDownload", language: language)
+    case .missingApp: return I18n.text("update.errorMissingApp", language: language)
+    case .notInstalled: return I18n.text("update.errorNotInstalled", language: language)
+    case .permission: return I18n.text("update.errorPermission", language: language)
+    case .checksum: return I18n.text("update.errorChecksum", language: language)
+    case .mount: return I18n.text("update.errorMount", language: language)
+    case .process(let message):
+      let fallback = I18n.text("update.errorProcess", language: language)
+      return message.map { "\(fallback): \($0)" } ?? fallback
     }
   }
 }

--- a/mac/Sources/LanguageStore.swift
+++ b/mac/Sources/LanguageStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Combine
+
+enum DokkeLanguage: String, CaseIterable, Identifiable {
+  case portuguese = "pt-BR"
+  case english = "en"
+
+  var id: String { rawValue }
+  var displayName: String {
+    switch self {
+    case .portuguese: return "Português"
+    case .english: return "English"
+    }
+  }
+}
+
+final class LanguageStore: ObservableObject {
+  static let defaultsKey = "dokke_language"
+
+  @Published private(set) var selected: DokkeLanguage
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard, preferredLanguages: [String] = Locale.preferredLanguages) {
+    self.defaults = defaults
+    if let saved = defaults.string(forKey: Self.defaultsKey),
+       let language = DokkeLanguage(rawValue: saved) {
+      selected = language
+    } else if preferredLanguages.first?.lowercased().hasPrefix("pt") == true {
+      selected = .portuguese
+    } else {
+      selected = .english
+    }
+  }
+
+  func select(_ language: DokkeLanguage) {
+    guard selected != language else {
+      defaults.set(language.rawValue, forKey: Self.defaultsKey)
+      return
+    }
+    selected = language
+    defaults.set(language.rawValue, forKey: Self.defaultsKey)
+  }
+}
+
+enum I18n {
+  static func text(_ key: String, language: DokkeLanguage) -> String {
+    let value = language == .english ? english[key] : portuguese[key]
+    return value ?? key
+  }
+
+  static func text(_ key: String, language: DokkeLanguage, _ values: [String: String]) -> String {
+    values.reduce(text(key, language: language)) { result, pair in
+      result.replacingOccurrences(of: "{" + pair.key + "}", with: pair.value)
+    }
+  }
+
+  private static let portuguese: [String: String] = [
+    "aria.language": "Idioma",
+    "sidebar.slots": "Slots", "sidebar.connect": "Conectar", "sidebar.hide": "Ocultar sidebar", "sidebar.show": "Mostrar sidebar",
+    "sidebar.selected": "Selecionado", "connect.title": "Conectar outro dispositivo", "connect.description": "Use o código abaixo no app ou navegador que você quer conectar ao Dokke.",
+    "connect.accessCode": "Código de acesso", "connect.openOther": "Abrir em outro dispositivo", "connect.scan": "Escaneie ou abra este endereço",
+    "connect.copyURL": "Copiar URL", "connect.open": "Abrir", "connect.network": "O Mac e o dispositivo precisam estar na mesma rede. Para iPhone/iPad, use uma URL HTTPS do túnel antes de adicionar à Tela de Início.",
+    "connect.noIP": "Sem IP de rede detectado (offline?)", "connect.online": "Servidor online", "connect.offline": "Servidor offline", "connect.devices": "{count} dispositivos", "connect.pinned": "{count} fixados",
+    "updates.title": "Atualizações", "updates.new": "Nova versão {version}", "updates.changes": "Mudanças", "updates.install": "Baixar e instalar", "updates.installed": "Versão instalada: {version}", "updates.check": "Verificar atualizações",
+    "confirm.newCode": "Gerar novo código?", "confirm.newCodeAction": "Gerar novo código", "confirm.cancel": "Cancelar", "confirm.newCodeMessage": "Os dispositivos conectados precisarão digitar o novo código.",
+    "accessCode.instruction": "Digite este código no dispositivo conectado", "release.changed": "O que mudou", "release.close": "Fechar",
+    "menu.device": "Dispositivo: {count}", "menu.pinned": "Fixados: {count}", "menu.open": "Abrir Dokke", "menu.sync": "Sincronizar agora", "menu.update": "Atualização {version} disponível", "menu.quit": "Sair", "menu.version": "Versão {version}",
+    "grid.drag": "Arraste para mover um ícone de posição.", "grid.page": "Página {page}", "grid.reorder.done": "Concluir", "grid.reorder": "Reorganizar apps", "grid.reorderHelp": "Concluir reorganização", "grid.offline": "Servidor Offline", "grid.offlineDescription": "Inicie o servidor Dokke e verifique a conexão na aba Conectar.",
+    "grid.add": "Adicionar app na posição {position}", "grid.move": "Mover app para a posição {position}", "grid.limit": "Limite de 5 páginas atingido", "grid.addHere": "Adicionar app nesta posição",
+    "picker.type": "Tipo de peça", "picker.apps": "Apps", "picker.websites": "Website Links", "picker.close": "Fechar", "picker.addApps": "Adicionar Apps", "picker.addLinks": "Adicionar links ao dock", "picker.library": "App Library", "picker.search": "Buscar apps...", "picker.limit": "Limite de 5 páginas atingido. Remova uma peça para adicionar outra.", "picker.loading": "Carregando apps…", "picker.none": "Nenhum app encontrado", "picker.noResults": "Sem resultados", "picker.serverEmpty": "O servidor não retornou apps instalados.", "picker.searchDifferent": "Tente uma busca diferente.", "picker.url": "https://exemplo.com", "picker.add": "Adicionar", "picker.suggestions": "Sugestões", "picker.added": "Adicionado", "picker.nameHint": "Vamos dar um nome curto para o seu weblink.", "picker.siteName": "Nome do site",
+    "icon.remove": "Remover", "icon.removeWebsite": "Remover site fixado", "icon.removeApp": "Remover app fixado", "icon.move": "Mover", "icon.removeDock": "Remover do Dock",
+    "update.checking": "Verificando atualizações...", "update.available": "Nova versão disponível.", "update.downloading": "Baixando a atualização...", "update.installing": "Instalando a atualização...", "update.current": "Você está na versão mais recente.",
+    "update.errorNetwork": "O GitHub não respondeu corretamente.", "update.errorInvalidRelease": "A release não contém um instalador macOS válido.", "update.errorDownload": "Não foi possível baixar a atualização.", "update.errorMissingApp": "O instalador não contém o Dokke.app.", "update.errorNotInstalled": "O Dokke precisa estar instalado como um aplicativo para ser atualizado.", "update.errorPermission": "Sem permissão para atualizar a pasta do Dokke. Mova o app para Aplicativos e tente novamente.", "update.errorChecksum": "A assinatura do download não confere com a release.", "update.errorMount": "Não foi possível montar o instalador.", "update.errorProcess": "Falha ao executar o instalador."
+  ]
+
+  private static let english: [String: String] = [
+    "aria.language": "Language",
+    "sidebar.slots": "Slots", "sidebar.connect": "Connect", "sidebar.hide": "Hide sidebar", "sidebar.show": "Show sidebar",
+    "sidebar.selected": "Selected", "connect.title": "Connect another device", "connect.description": "Use the code below in the app or browser you want to connect to Dokke.",
+    "connect.accessCode": "Access code", "connect.openOther": "Open on another device", "connect.scan": "Scan or open this address",
+    "connect.copyURL": "Copy URL", "connect.open": "Open", "connect.network": "Your Mac and device must be on the same network. For iPhone/iPad, use an HTTPS tunnel URL before adding it to the Home Screen.",
+    "connect.noIP": "No network IP detected (offline?)", "connect.online": "Server online", "connect.offline": "Server offline", "connect.devices": "{count} devices", "connect.pinned": "{count} pinned",
+    "updates.title": "Updates", "updates.new": "New version {version}", "updates.changes": "Changes", "updates.install": "Download and install", "updates.installed": "Installed version: {version}", "updates.check": "Check for updates",
+    "confirm.newCode": "Generate a new code?", "confirm.newCodeAction": "Generate new code", "confirm.cancel": "Cancel", "confirm.newCodeMessage": "Connected devices will need to enter the new code.",
+    "accessCode.instruction": "Enter this code on the connected device", "release.changed": "What changed", "release.close": "Close",
+    "menu.device": "Device: {count}", "menu.pinned": "Pinned: {count}", "menu.open": "Open Dokke", "menu.sync": "Sync now", "menu.update": "Update {version} available", "menu.quit": "Quit", "menu.version": "Version {version}",
+    "grid.drag": "Drag to move an icon.", "grid.page": "Page {page}", "grid.reorder.done": "Done", "grid.reorder": "Reorder apps", "grid.reorderHelp": "Finish reordering", "grid.offline": "Server Offline", "grid.offlineDescription": "Start the Dokke server and check the connection in the Connect tab.",
+    "grid.add": "Add app at position {position}", "grid.move": "Move app to position {position}", "grid.limit": "Limit of 5 pages reached", "grid.addHere": "Add app in this position",
+    "picker.type": "Piece type", "picker.apps": "Apps", "picker.websites": "Website Links", "picker.close": "Close", "picker.addApps": "Add Apps", "picker.addLinks": "Add links to dock", "picker.library": "App Library", "picker.search": "Search apps...", "picker.limit": "Limit of 5 pages reached. Remove a piece to add another.", "picker.loading": "Loading apps…", "picker.none": "No app found", "picker.noResults": "No results", "picker.serverEmpty": "The server returned no installed apps.", "picker.searchDifferent": "Try a different search.", "picker.url": "https://example.com", "picker.add": "Add", "picker.suggestions": "Suggestions", "picker.added": "Added", "picker.nameHint": "Let's give your weblink a short name.", "picker.siteName": "Site name",
+    "icon.remove": "Remove", "icon.removeWebsite": "Remove pinned site", "icon.removeApp": "Remove pinned app", "icon.move": "Move", "icon.removeDock": "Remove from Dock",
+    "update.checking": "Checking for updates...", "update.available": "New version available.", "update.downloading": "Downloading update...", "update.installing": "Installing update...", "update.current": "You are up to date.",
+    "update.errorNetwork": "GitHub did not respond correctly.", "update.errorInvalidRelease": "The release does not contain a valid macOS installer.", "update.errorDownload": "The update could not be downloaded.", "update.errorMissingApp": "The installer does not contain Dokke.app.", "update.errorNotInstalled": "Dokke must be installed as an application to update.", "update.errorPermission": "You do not have permission to update Dokke's folder. Move the app to Applications and try again.", "update.errorChecksum": "The download signature does not match the release.", "update.errorMount": "The installer could not be mounted.", "update.errorProcess": "The installer could not be executed."
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -772,17 +772,17 @@
       <div class="lkey" aria-hidden="true">
         <img src="/icon-192.png" alt="" aria-hidden="true" width="54" height="54">
       </div>
-      <h3 id="loginTitle">Conectar ao Dokke</h3>
-      <div class="body">Conecte o aparelho ao seu Mac para abrir os apps.</div>
+      <h3 id="loginTitle" data-i18n="login.title">Conectar ao Dokke</h3>
+      <div class="body" data-i18n="login.description">Conecte o aparelho ao seu Mac para abrir os apps.</div>
       <ol class="lsteps">
-        <li><span class="lnum">1</span><div><p>Conecte o Mac e este aparelho à <b>mesma rede Wi-Fi</b>.</p></div></li>
-        <li><span class="lnum">2</span><div><p>No Mac, abra o <b>Dokke</b> e escolha os apps que quer usar.</p></div></li>
-        <li><span class="lnum">3</span><div><p>Toque em <b>Gerar novo código</b> no Mac e digite o código de 4 dígitos aqui.</p></div></li>
+        <li><span class="lnum">1</span><div><p><span data-i18n="login.step1Prefix">Conecte o Mac e este aparelho à</span> <b data-i18n="login.sameNetwork">mesma rede Wi-Fi</b>.</p></div></li>
+        <li><span class="lnum">2</span><div><p><span data-i18n="login.step2Prefix">No Mac, abra o</span> <b>Dokke</b> <span data-i18n="login.step2Suffix">e escolha os apps que quer usar.</span></p></div></li>
+        <li><span class="lnum">3</span><div><p><span data-i18n="login.step3Prefix">Toque em</span> <b data-i18n="login.generateCode">Gerar novo código</b> <span data-i18n="login.step3Suffix">no Mac e digite o código de 4 dígitos aqui.</span></p></div></li>
       </ol>
-      <input id="loginPin" inputmode="numeric" autocomplete="one-time-code" maxlength="4" placeholder="••••" aria-label="Código de acesso">
+      <input id="loginPin" inputmode="numeric" autocomplete="one-time-code" maxlength="4" placeholder="••••" aria-label="Código de acesso" data-i18n-aria-label="login.pinLabel">
       <div class="lerr" id="loginErr"></div>
-      <button class="btn connect" id="loginGo">Conectar</button>
-      <p class="lfoot">Dokke by Felipe Natanael</p>
+      <button class="btn connect" id="loginGo" data-i18n="login.connect">Conectar</button>
+      <p class="lfoot" data-i18n="footer.brand">Dokke by Felipe Natanael</p>
     </div>
   </div>
 
@@ -798,14 +798,14 @@
     </div>
     <div class="up-actions">
       <button class="up-download" id="upDownload">Baixar</button>
-      <button class="up-x" id="upX" aria-label="Fechar aviso">✕</button>
+      <button class="up-x" id="upX" aria-label="Fechar aviso" data-i18n-aria-label="aria.close">✕</button>
     </div>
   </div>
 
   <aside class="drawer" id="drawer">
     <div class="drawer-head">
-      <h2>OBS Commander</h2>
-      <button class="drawer-close" id="drawerClose" aria-label="Fechar">✕</button>
+      <h2 data-i18n="obs.title">OBS Commander</h2>
+      <button class="drawer-close" id="drawerClose" aria-label="Fechar" data-i18n-aria-label="aria.close">✕</button>
     </div>
     <div class="drawer-body" id="obspanel"></div>
   </aside>
@@ -827,6 +827,106 @@
   } catch {}
 
   const $ = id => document.getElementById(id);
+
+  const I18N = {
+    "pt-BR": {
+      "aria.language": "Idioma", "aria.selectLanguage": "Selecionar idioma", "aria.close": "Fechar",
+      "login.title": "Conectar ao Dokke", "login.description": "Conecte o aparelho ao seu Mac para abrir os apps.",
+      "login.step1Prefix": "Conecte o Mac e este aparelho à", "login.sameNetwork": "mesma rede Wi-Fi",
+      "login.step2Prefix": "No Mac, abra o", "login.step2Suffix": "e escolha os apps que quer usar.",
+      "login.step3Prefix": "Toque em", "login.generateCode": "Gerar novo código", "login.step3Suffix": "no Mac e digite o código de 4 dígitos aqui.",
+      "login.pinLabel": "Código de acesso", "login.connect": "Conectar", "login.invalidCode": "Código inválido",
+      "login.tooMany": "Muitas tentativas — aguarde um pouco.", "login.wrongCode": "Código errado.",
+      "dock.openApps": "Apps abertos", "dock.apps": "Apps", "dock.pinned": "Favoritos", "dock.tapToOpen": "Toque em um app para abrir",
+      "recents.title": "Apps abertos", "recents.empty": "Nada aberto ainda — abra um app no Mac para ele aparecer aqui",
+      "modal.pinTitle": "Fixar apps como favoritos",
+      "dock.opened": "aberto", "dock.noOpenApps": "Nada aberto ainda — abra um app no Mac para ele aparecer aqui",
+      "dock.pinApps": "Fixar apps como favoritos", "dock.pinSubtitle": "Escolha os apps que aparecem no Launchpad.",
+      "dock.pinnedLabel": "fixado", "dock.limit": "limite", "dock.pin": "+ fixar", "dock.close": "Fechar",
+      "modal.removeWebsite": "Remover website dos favoritos?", "modal.removeApp": "Remover dos favoritos?",
+      "modal.removeWebsiteBody": "\"{name}\" sai dos fixos.",
+      "modal.removeAppBody": "\"{name}\" sai dos fixos. O app continua no Launchpad.",
+      "modal.cancel": "Cancelar", "modal.removeConfirm": "Remover", "modal.stopAllTitle": "Encerrar transmissão?",
+      "modal.stopAllBody": "O OBS vai parar a gravação e a live.", "modal.stopAll": "Encerrar tudo",
+      "toast.macDisconnected": "Mac desconectado", "toast.deviceConnected": "Dispositivo conectado",
+      "toast.pinAdded": "\"{name}\" adicionado aos favoritos", "toast.removed": "\"{name}\" removido",
+      "toast.pinFailed": "Falha ao fixar", "toast.openFailed": "Não consegui abrir \"{name}\"",
+      "toast.removeFailed": "Falha ao remover", "toast.dockChanged": "O dock mudou; tente novamente",
+      "toast.pinnedLimit": "Limite de {pages} páginas atingido", "toast.obsOffline": "OBS offline",
+      "toast.obsCommandFailed": "Comando OBS falhou", "toast.updated": "Atualizando…",
+      "obs.title": "OBS Commander", "obs.offline": "OBS offline — abra o OBS para liberar as cenas",
+      "obs.unavailable": "OBS indisponível — verifique o WebSocket", "obs.live": "AO VIVO", "obs.connected": "conectado",
+      "obs.startRecording": "Gravar", "obs.stopRecording": "Parar", "obs.startLive": "Live", "obs.stopLive": "Parar live", "obs.stopAll": "Encerrar",
+      "obs.accessibility": "OBS, {status}",
+      "update.available": "Nova atualização do Dokke", "update.version": "Versão {version} disponível. Escolha quando baixar.",
+      "update.download": "Baixar", "update.reload": "Recarregar", "update.release": "Abrir release", "update.macTitle": "App do Mac desatualizado",
+      "update.macSubtitle": "Nova versão {version} disponível — atualize o Dokke no computador",
+      "update.close": "Fechar aviso", "site": "site", "footer.brand": "Dokke by Felipe Natanael"
+    },
+    en: {
+      "aria.language": "Language", "aria.selectLanguage": "Select language", "aria.close": "Close",
+      "login.title": "Connect to Dokke", "login.description": "Connect this device to your Mac to open apps.",
+      "login.step1Prefix": "Connect your Mac and this device to the", "login.sameNetwork": "same Wi-Fi network",
+      "login.step2Prefix": "On your Mac, open", "login.step2Suffix": "and choose the apps you want to use.",
+      "login.step3Prefix": "Tap", "login.generateCode": "Generate new code", "login.step3Suffix": "on your Mac and enter the 4-digit code here.",
+      "login.pinLabel": "Access code", "login.connect": "Connect", "login.invalidCode": "Invalid code",
+      "login.tooMany": "Too many attempts — please wait a moment.", "login.wrongCode": "Wrong code.",
+      "dock.openApps": "Open apps", "dock.apps": "Apps", "dock.pinned": "Favorites", "dock.tapToOpen": "Tap an app to open it",
+      "recents.title": "Open apps", "recents.empty": "Nothing open yet — open an app on your Mac to see it here",
+      "modal.pinTitle": "Pin apps as favorites",
+      "dock.opened": "open", "dock.noOpenApps": "Nothing open yet — open an app on your Mac to see it here",
+      "dock.pinApps": "Pin apps as favorites", "dock.pinSubtitle": "Choose the apps that appear in Launchpad.",
+      "dock.pinnedLabel": "pinned", "dock.limit": "limit", "dock.pin": "+ pin", "dock.close": "Close",
+      "modal.removeWebsite": "Remove website from favorites?", "modal.removeApp": "Remove from favorites?",
+      "modal.removeWebsiteBody": "\"{name}\" will be unpinned.",
+      "modal.removeAppBody": "\"{name}\" will be unpinned. The app stays in Launchpad.",
+      "modal.cancel": "Cancel", "modal.removeConfirm": "Remove", "modal.stopAllTitle": "Stop broadcast?",
+      "modal.stopAllBody": "OBS will stop recording and the live stream.", "modal.stopAll": "Stop everything",
+      "toast.macDisconnected": "Mac disconnected", "toast.deviceConnected": "Device connected",
+      "toast.pinAdded": "\"{name}\" added to favorites", "toast.removed": "\"{name}\" removed",
+      "toast.pinFailed": "Failed to pin", "toast.openFailed": "Could not open \"{name}\"",
+      "toast.removeFailed": "Failed to remove", "toast.dockChanged": "The dock changed; try again",
+      "toast.pinnedLimit": "Limit of {pages} pages reached", "toast.obsOffline": "OBS offline",
+      "toast.obsCommandFailed": "OBS command failed", "toast.updated": "Updating…",
+      "obs.title": "OBS Commander", "obs.offline": "OBS offline — open OBS to enable scenes",
+      "obs.unavailable": "OBS unavailable — check the WebSocket", "obs.live": "LIVE", "obs.connected": "connected",
+      "obs.startRecording": "Record", "obs.stopRecording": "Stop", "obs.startLive": "Live", "obs.stopLive": "Stop live", "obs.stopAll": "Stop",
+      "obs.accessibility": "OBS, {status}",
+      "update.available": "New Dokke update", "update.version": "Version {version} is available. Choose when to download it.",
+      "update.download": "Download", "update.reload": "Reload", "update.release": "Open release", "update.macTitle": "Mac app is out of date",
+      "update.macSubtitle": "Version {version} is available — update Dokke on your computer",
+      "update.close": "Close notice", "site": "site", "footer.brand": "Dokke by Felipe Natanael"
+    }
+  };
+  function detectLanguage(language = navigator.language){
+    if (typeof language !== "string" || !language.trim()) return "pt-BR";
+    return language.toLowerCase().startsWith("pt") ? "pt-BR" : "en";
+  }
+  function getInitialLanguage(){
+    let browserLanguage = null;
+    try { browserLanguage = typeof navigator !== "undefined" ? navigator.language : null; } catch (e) {}
+    return detectLanguage(browserLanguage);
+  }
+  let currentLanguage = getInitialLanguage();
+  function t(key, values = {}){
+    const template = (I18N[currentLanguage] && I18N[currentLanguage][key]) || I18N["pt-BR"][key] || key;
+    return Object.entries(values).reduce(function(text, entry){
+      return text.split("{" + entry[0] + "}").join(String(entry[1]));
+    }, template);
+  }
+  function renderLanguage(){
+    document.documentElement.lang = currentLanguage;
+    document.querySelectorAll("[data-i18n]").forEach(function(element){
+      element.textContent = t(element.dataset.i18n);
+    });
+    document.querySelectorAll("[data-i18n-aria-label]").forEach(function(element){
+      element.setAttribute("aria-label", t(element.dataset.i18nAriaLabel));
+    });
+    document.querySelectorAll("[data-i18n-placeholder]").forEach(function(element){
+      element.setAttribute("placeholder", t(element.dataset.i18nPlaceholder));
+    });
+  }
+  renderLanguage();
 
   const PALETTE = [
     ["#0a84ff","#5e5ce6"], ["#ff375f","#ff9f0a"], ["#30d158","#0a84ff"],
@@ -910,13 +1010,13 @@
   }
   function loginError(msg){
     const err = $("loginErr");
-    if (err) err.textContent = msg || "código inválido";
+    if (err) err.textContent = msg || t("login.invalidCode");
   }
   async function doLogin(){
     const pin = $("loginPin");
     const val = (pin && pin.value || "").trim();
     if (loginOpen === false) return;
-    if (!/^\d{4}$/.test(val)){ loginError("código inválido"); return; }
+    if (!/^\d{4}$/.test(val)){ loginError(t("login.invalidCode")); return; }
     const r = await post("/api/auth", { pin: val }).catch(function(){ return { status: 0, data: null }; });
     if (r && r.status === 200 && r.data && r.data.ok === true){
       authed = true;
@@ -927,9 +1027,9 @@
       hideLogin();
       boot();
     } else if (r && r.status === 429){
-      loginError("Muitas tentativas — aguarde um pouco.");
+      loginError(t("login.tooMany"));
     } else {
-      loginError("Código errado.");
+      loginError(t("login.wrongCode"));
     }
   }
   $("loginGo").addEventListener("click", doLogin);
@@ -972,7 +1072,7 @@
   }
 
   function pinnedLimitMessage(){
-    return "Limite de " + state.maxPinnedPages + " páginas atingido";
+    return t("toast.pinnedLimit", { pages: state.maxPinnedPages });
   }
 
   async function req(path, opts){
@@ -1132,8 +1232,8 @@
     const pid = run && Number.isInteger(run.pid) && run.pid > 0 ? run.pid : undefined;
     let r;
     try { r = await post("/api/apps/" + encodeURIComponent(name) + "/activate", { pid: pid }); }
-    catch (e) { toast("Mac desconectado", "err"); return; }
-    if (!r || r.data.ok !== true) toast("Não consegui abrir \"" + name + "\"", "err");
+    catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
+    if (!r || r.data.ok !== true) toast(t("toast.openFailed", { name: name }), "err");
     else loadApps();
   }
 
@@ -1142,8 +1242,8 @@
     if (piece.type !== "website") return activateApp(piece.name);
     let r;
     try { r = await post("/api/pieces/" + encodeURIComponent(piece.id) + "/open"); }
-    catch (e) { toast("Mac desconectado", "err"); return; }
-    if (!r || !r.data || r.data.ok !== true) toast("Não consegui abrir \"" + (piece.title || "site") + "\"", "err");
+    catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
+    if (!r || !r.data || r.data.ok !== true) toast(t("toast.openFailed", { name: piece.title || t("site") }), "err");
   }
 
   async function pinApp(name){
@@ -1153,21 +1253,21 @@
     }
     let r;
     try { r = await post("/api/config/pinned", { app: name }); }
-    catch (e) { toast("Mac desconectado", "err"); return; }
-    if (r && r.data.ok === true){ toast("\"" + name + "\" adicionado aos favoritos"); loadApps(); }
+    catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
+    if (r && r.data.ok === true){ toast(t("toast.pinAdded", { name: name })); loadApps(); }
     else if (r && r.data && r.data.code === "PINNED_LIMIT_REACHED") {
       applyPinnedLimits(r.data.limits);
       toast(r.data.error || pinnedLimitMessage(), "err");
     }
-    else toast("Falha ao fixar", "err");
+    else toast(t("toast.pinFailed"), "err");
   }
 
   async function unpinApp(name){
     let r;
     try { r = await req("/api/config/pinned/" + encodeURIComponent(name), { method: "DELETE", timeout: 4000 }); }
-    catch (e) { toast("Mac desconectado", "err"); return; }
-    if (r.data && r.data.ok === true){ toast("\"" + name + "\" removido"); loadApps(); }
-    else toast("Falha ao remover", "err");
+    catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
+    if (r.data && r.data.ok === true){ toast(t("toast.removed", { name: name })); loadApps(); }
+    else toast(t("toast.removeFailed"), "err");
   }
 
   async function unpinPiece(id){
@@ -1180,12 +1280,12 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ revision: state.revision }),
       });
-    } catch (e) { toast("Mac desconectado", "err"); return; }
-    if (r.data && r.data.ok === true){ toast("\"" + (piece.title || piece.name) + "\" removido"); loadApps(); }
+    } catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
+    if (r.data && r.data.ok === true){ toast(t("toast.removed", { name: piece.title || piece.name })); loadApps(); }
     else if (r.data && r.data.code === "REVISION_CONFLICT"){
       applyConfigSnapshot(r.data.config);
-      toast("O dock mudou; tente novamente", "err");
-    } else toast("Falha ao remover", "err");
+      toast(t("toast.dockChanged"), "err");
+    } else toast(t("toast.removeFailed"), "err");
   }
 
   function applyConfigSnapshot(config){
@@ -1227,7 +1327,7 @@
     const piece = typeof el === "object" && el && el.type ? el : null;
     const isWebsite = piece && piece.type === "website";
     const name = piece
-      ? (piece.title || piece.url || "site")
+      ? (piece.title || piece.url || t("site"))
       : (typeof el === "string" ? el : (el && el.dataset ? el.dataset.name : ""));
     if (!name) return;
     const content = document.createDocumentFragment();
@@ -1264,25 +1364,25 @@
     }
     content.appendChild(icon);
     const title = document.createElement("h3");
-    title.textContent = isWebsite ? "Remover website dos favoritos?" : "Remover dos favoritos?";
+    title.textContent = isWebsite ? t("modal.removeWebsite") : t("modal.removeApp");
     content.appendChild(title);
     const body = document.createElement("div");
     body.className = "body";
     body.textContent = isWebsite
-      ? "\"" + name + "\" sai dos fixos."
-      : "\"" + name + "\" sai dos fixos. O app continua no Launchpad.";
+      ? t("modal.removeWebsiteBody", { name: name })
+      : t("modal.removeAppBody", { name: name });
     content.appendChild(body);
     const btns = document.createElement("div");
     btns.className = "btns";
     const cancel = document.createElement("button");
     cancel.className = "btn ghost";
     cancel.dataset.sclose = "";
-    cancel.textContent = "Cancelar";
+    cancel.textContent = t("modal.cancel");
     btns.appendChild(cancel);
     const confirm = document.createElement("button");
     confirm.className = "btn danger";
     confirm.dataset.confirm = "";
-    confirm.textContent = "Remover";
+    confirm.textContent = t("modal.removeConfirm");
     btns.appendChild(confirm);
     content.appendChild(btns);
     modal(
@@ -1398,11 +1498,11 @@
   }
 
   function buildTile(a, withIcon){
-    const t = document.createElement("div");
-    t.className = "atile";
-    t.dataset.id = a.id;
-    t.dataset.type = a.type;
-    if (a.type === "app") t.dataset.name = a.name;
+    const tile = document.createElement("div");
+    tile.className = "atile";
+    tile.dataset.id = a.id;
+    tile.dataset.type = a.type;
+    if (a.type === "app") tile.dataset.name = a.name;
     const glass = document.createElement("div");
     glass.className = "aglass";
     const websitePlate = a.type === "website" ? document.createElement("div") : null;
@@ -1439,19 +1539,19 @@
     if (a.type === "website") img.src = websiteFaviconPath(a.url);
     else if (withIcon) loadIcon(a.name, img, glass);
     else img.src = iconPath(a.name);
-    t.appendChild(glass);
+    tile.appendChild(glass);
     const nm = document.createElement("span");
     nm.className = "aname";
     nm.textContent = a.type === "website" ? a.title : a.name;
     const st = document.createElement("span");
     st.className = "astatus";
-    st.textContent = a.type === "app" && isRunning(a.name) ? "aberto" : "";
+    st.textContent = a.type === "app" && isRunning(a.name) ? t("dock.opened") : "";
     if (a.type === "app" && isRunning(a.name)) st.classList.add("on");
-    t.appendChild(nm);
-    t.appendChild(st);
-    makeBtn(t, a.type === "website" ? a.title : a.name, function(){ activatePiece(a); });
-    bindHold(t, tileLong);
-    return t;
+    tile.appendChild(nm);
+    tile.appendChild(st);
+    makeBtn(tile, a.type === "website" ? a.title : a.name, function(){ activatePiece(a); });
+    bindHold(tile, tileLong);
+    return tile;
   }
 
   function buildEmptyTile(){
@@ -1777,7 +1877,7 @@
     head.className = "thead";
     const title = document.createElement("div");
     title.className = "ttitle";
-    title.textContent = "Apps abertos";
+    title.textContent = t("recents.title");
     head.appendChild(title);
     sc.appendChild(head);
 
@@ -1791,7 +1891,7 @@
     if (!q.length){
       const e = document.createElement("div");
       e.className = "rempty";
-      e.textContent = "Nada aberto ainda — abra um app no Mac para ele aparecer aqui";
+      e.textContent = t("recents.empty");
       stage.appendChild(e);
     }
 
@@ -1811,21 +1911,21 @@
       mid.appendChild(ot);
       const os = document.createElement("div");
       os.className = "os";
-      os.textContent = state.obs.recording ? "gravando" : state.obs.streaming ? "ao vivo" : (state.obs.connected ? "conectado" : "offline");
+      os.textContent = state.obs.recording ? t("obs.stopRecording") : state.obs.streaming ? t("obs.live") : (state.obs.connected ? t("obs.connected") : t("toast.obsOffline"));
       mid.appendChild(os);
       card.appendChild(mid);
       const arr = document.createElement("span");
       arr.className = "arr";
       arr.textContent = "›";
       card.appendChild(arr);
-      makeBtn(card, "OBS, " + os.textContent, openDrawer);
+      makeBtn(card, t("obs.accessibility", { status: os.textContent }), openDrawer);
       sc.appendChild(card);
     }
 
     if (q.length){
       const hint = document.createElement("div");
       hint.className = "thint";
-      hint.textContent = "Toque em um app para abrir";
+      hint.textContent = t("dock.tapToOpen");
       sc.appendChild(hint);
     }
 
@@ -1838,13 +1938,13 @@
   function openPinSheet(){
     const kids = [];
     const head = document.createElement("h3");
-    head.textContent = "Fixar apps como favoritos";
+    head.textContent = t("modal.pinTitle");
     kids.push(head);
     const sub = document.createElement("div");
     sub.style.cssText = "margin-bottom:10px;color:var(--ink-3);font-size:12px";
     sub.textContent = state.pieces.length >= state.maxPinnedPieces
-      ? pinnedLimitMessage() + ". Remova uma peça para adicionar outra."
-      : state.installed.length + " apps instalados";
+      ? pinnedLimitMessage() + ". " + (currentLanguage === "en" ? "Remove a piece to add another." : "Remova uma peça para adicionar outra.")
+      : state.installed.length + (currentLanguage === "en" ? " installed apps" : " apps instalados");
     if (state.pieces.length >= state.maxPinnedPieces) sub.style.color = "var(--amber)";
     kids.push(sub);
     state.installed.forEach(function(a){
@@ -1871,10 +1971,10 @@
       const pin = document.createElement("span");
       pin.className = "pin";
       const limitReached = !pinned && state.pieces.length >= state.maxPinnedPieces;
-      pin.textContent = pinned ? "✓ fixado" : (limitReached ? "limite" : "+ fixar");
+      pin.textContent = pinned ? "✓ " + t("dock.pinnedLabel") : (limitReached ? t("dock.limit") : t("dock.pin"));
       if (limitReached) pin.style.color = "var(--amber)";
       row.appendChild(pin);
-      makeBtn(row, a.name + (pinned ? ", fixado" : ", fixar"), function(el){
+      makeBtn(row, a.name + (pinned ? ", " + t("dock.pinnedLabel") : ", " + t("dock.pin")), function(el){
         if (state.pinned.indexOf(el.dataset.name) !== -1) unpinApp(el.dataset.name);
         else if (state.pieces.length >= state.maxPinnedPieces) toast(pinnedLimitMessage(), "err");
         else pinApp(el.dataset.name);
@@ -1886,7 +1986,7 @@
     btns.className = "btns";
     const btn = document.createElement("button");
     btn.className = "btn ghost";
-    btn.textContent = "Fechar";
+    btn.textContent = t("dock.close");
     btn.addEventListener("click", closeModal);
     btns.appendChild(btn);
     kids.push(btns);
@@ -1902,7 +2002,7 @@
     const panel = $("obspanel");
     const o = state.obs;
     if (!o.connected){
-      const msg = o.error ? "OBS indisponível — verifique o WebSocket" : "OBS offline — abra o OBS para liberar as cenas";
+      const msg = o.error ? t("obs.unavailable") : t("obs.offline");
       const placeholder = document.createElement("div");
       placeholder.className = "obsplaceholder";
       const icon = document.createElement("span");
@@ -1918,14 +2018,14 @@
     top.className = "obstop";
     const title = document.createElement("span");
     title.className = "obstitle";
-    title.textContent = "OBS Commander";
+    title.textContent = t("obs.title");
     top.appendChild(title);
     const led = document.createElement("span");
     led.className = "led on";
     const ledDot = document.createElement("span");
     ledDot.className = "d";
     led.appendChild(ledDot);
-    led.appendChild(document.createTextNode(o.streaming ? "AO VIVO" : "conectado"));
+    led.appendChild(document.createTextNode(o.streaming ? t("obs.live") : t("obs.connected")));
     top.appendChild(led);
 
     const scenePanel = document.createElement("div");
@@ -1949,7 +2049,7 @@
     recIcon.textContent = "●";
     rec.appendChild(recIcon);
     const recLabel = document.createElement("span");
-    recLabel.textContent = o.recording ? "Parar" : "Gravar";
+    recLabel.textContent = o.recording ? t("obs.stopRecording") : t("obs.startRecording");
     rec.appendChild(recLabel);
     controls.appendChild(rec);
 
@@ -1961,7 +2061,7 @@
     streamIcon.textContent = "▲";
     stream.appendChild(streamIcon);
     const streamLabel = document.createElement("span");
-    streamLabel.textContent = o.streaming ? "Parar" : "Live";
+    streamLabel.textContent = o.streaming ? t("obs.stopLive") : t("obs.startLive");
     stream.appendChild(streamLabel);
     controls.appendChild(stream);
 
@@ -1973,7 +2073,7 @@
     stopIcon.textContent = "■";
     stop.appendChild(stopIcon);
     const stopLabel = document.createElement("span");
-    stopLabel.textContent = "Encerrar";
+    stopLabel.textContent = t("obs.stopAll");
     stop.appendChild(stopLabel);
     controls.appendChild(stop);
 
@@ -1989,11 +2089,11 @@
 
   function confirmStopAll(){
     modal(
-      "<h3>Encerrar transmissão?</h3>" +
-      "<div class=\"body\">O OBS vai parar a gravação e a live.</div>" +
+      "<h3>" + t("modal.stopAllTitle") + "</h3>" +
+      "<div class=\"body\">" + t("modal.stopAllBody") + "</div>" +
       "<div class=\"btns\">" +
-      "<button class=\"btn ghost\" data-sclose>Cancelar</button>" +
-      "<button class=\"btn danger\" data-confirm>Encerrar tudo</button>" +
+      "<button class=\"btn ghost\" data-sclose>" + t("modal.cancel") + "</button>" +
+      "<button class=\"btn danger\" data-confirm>" + t("modal.stopAll") + "</button>" +
       "</div>",
       function(){
         $("sheet").querySelector("[data-sclose]").addEventListener("click", closeModal);
@@ -2004,11 +2104,11 @@
   async function doObs(kind, body){
     let r;
     try { r = await post("/api/obs/" + encodeURIComponent(kind), body); }
-    catch (e) { toast("Mac desconectado", "err"); return; }
+    catch (e) { toast(t("toast.macDisconnected"), "err"); return; }
     const d = r.data || {};
     if (d.ok === true) obsSyncSoon();
-    else if (d.connected === false){ toast("OBS offline", "err"); obsSyncSoon(); }
-    else toast("Comando OBS falhou", "err");
+    else if (d.connected === false){ toast(t("toast.obsOffline"), "err"); obsSyncSoon(); }
+    else toast(t("toast.obsCommandFailed"), "err");
   }
 
   let syncT = null;
@@ -2043,7 +2143,7 @@
     if (!v) return;
     if (uiVersionSeen === null){ uiVersionSeen = v; return; }
     if (uiVersionSeen !== v){
-      toast("Atualizando…", "");
+      toast(t("toast.updated"), "");
       setTimeout(function(){ location.reload(); }, 600);
     }
   }
@@ -2114,8 +2214,8 @@
       ok = (r.status === 200) && r.data && r.data.ok === true;
     } catch (e) { ok = false; }
     state.online = ok;
-    if (prev && !ok) toast("Mac desconectado", "err");
-    if (!prev && ok) toast("Dispositivo conectado");
+    if (prev && !ok) toast(t("toast.macDisconnected"), "err");
+    if (!prev && ok) toast(t("toast.deviceConnected"));
     healthBackoff = ok ? HEALTH_OK : Math.min(healthBackoff * 2, POLL_MAX);
     healthT = setTimeout(loadHealth, healthBackoff);
   }
@@ -2280,7 +2380,7 @@
       const st = at[i].querySelector(".astatus");
       if (!st) continue;
       const on = running.has(at[i].dataset.name);
-      if (on){ st.textContent = "aberto"; st.classList.add("on"); }
+      if (on){ st.textContent = t("dock.opened"); st.classList.add("on"); }
       else { st.textContent = ""; st.classList.remove("on"); }
     }
   }
@@ -2890,7 +2990,7 @@
     $("upSub").textContent = sub;
     const download = $("upDownload");
     const isAndroid = !!(window.DokkeAndroid && window.DokkeAndroid.requestUpdate);
-    download.textContent = isAndroid ? "Baixar" : "Abrir release";
+    download.textContent = isAndroid ? t("update.download") : t("update.release");
     download.onclick = function(e){
       e.stopPropagation();
       if (isAndroid){
@@ -2939,8 +3039,8 @@
           }
           if (!apkNow || !rel || !rel.tag) return;
           if (cmpVer(rel.tag, apkNow) > 0){
-            showUpBanner("Nova atualização do Dokke",
-              "Versão " + rel.tag + " disponível. Escolha quando baixar.",
+            showUpBanner(t("update.available"),
+              t("update.version", { version: rel.tag }),
               rel.apkUrl || "https://github.com/felipenalves/Dokke/releases/latest/download/dokke.apk",
               rel.tag);
           }
@@ -2948,8 +3048,8 @@
         }
         // Mac (servidor embutido) desatualizado
         if (rel && rel.tag && cmpVer(rel.tag, v.local.tag) > 0){
-          showUpBanner("App do Mac desatualizado",
-            "Nova versão " + rel.tag + " disponível — atualize o Dokke no computador",
+          showUpBanner(t("update.macTitle"),
+            t("update.macSubtitle", { version: rel.tag }),
             rel.htmlUrl || "https://github.com/felipenalves/Dokke/releases/latest");
         }
       })

--- a/public/index.html
+++ b/public/index.html
@@ -963,7 +963,7 @@
   }
 
   // ---------- login wall (pin de acesso) ----------
-  let authed = false, loginOpen = false;
+  let authed = false, loginOpen = false, loginSubmitting = false;
   function syncLoginViewport(){
     const scrim = $("loginScrim");
     const vv = window.visualViewport;
@@ -1013,26 +1013,38 @@
     if (err) err.textContent = msg || t("login.invalidCode");
   }
   async function doLogin(){
+    if (loginSubmitting) return;
     const pin = $("loginPin");
     const val = (pin && pin.value || "").trim();
     if (loginOpen === false) return;
     if (!/^\d{4}$/.test(val)){ loginError(t("login.invalidCode")); return; }
-    const r = await post("/api/auth", { pin: val }).catch(function(){ return { status: 0, data: null }; });
-    if (r && r.status === 200 && r.data && r.data.ok === true){
-      authed = true;
-      // tira o foco do input pra o teclado recuar (mobile/WebView)
-      const active = document.activeElement;
-      if (active && active.blur) active.blur();
-      try { if (window.DokkeAndroid) window.DokkeAndroid.hideKeyboard(); } catch (e) {}
-      hideLogin();
-      boot();
-    } else if (r && r.status === 429){
-      loginError(t("login.tooMany"));
-    } else {
-      loginError(t("login.wrongCode"));
+    loginSubmitting = true;
+    try {
+      const r = await post("/api/auth", { pin: val }).catch(function(){ return { status: 0, data: null }; });
+      if (r && r.status === 200 && r.data && r.data.ok === true){
+        authed = true;
+        // tira o foco do input pra o teclado recuar (mobile/WebView)
+        const active = document.activeElement;
+        if (active && active.blur) active.blur();
+        try { if (window.DokkeAndroid) window.DokkeAndroid.hideKeyboard(); } catch (e) {}
+        hideLogin();
+        boot();
+      } else if (r && r.status === 429){
+        loginError(t("login.tooMany"));
+      } else {
+        loginError(t("login.wrongCode"));
+      }
+    } finally {
+      loginSubmitting = false;
     }
   }
   $("loginGo").addEventListener("click", doLogin);
+  $("loginPin").addEventListener("input", function(){
+    const input = $("loginPin");
+    const normalized = (input.value || "").replace(/\D/g, "").slice(0, 4);
+    if (input.value !== normalized) input.value = normalized;
+    if (normalized.length === 4) doLogin();
+  });
   $("loginPin").addEventListener("keydown", function(e){
     if (e.key === "Enter") doLogin();
     else if (!/^\d$/.test(e.key) && e.key.length === 1) e.preventDefault();

--- a/test/issue-19-i18n.test.mjs
+++ b/test/issue-19-i18n.test.mjs
@@ -201,6 +201,21 @@ test("PWA não expõe seletor manual de idioma", () => {
   assert.doesNotMatch(html, /data-language-control/);
 });
 
+test("login valida o PIN automaticamente no quarto dígito", () => {
+  const doLogin = extractFunction(html, "doLogin");
+  assert.ok(doLogin, "faltou function doLogin()");
+  assert.match(html, /loginSubmitting = false/);
+  assert.match(doLogin, /if \(loginSubmitting\) return/);
+  assert.match(doLogin, /loginSubmitting = true/);
+  assert.match(doLogin, /finally \{[\s\S]*loginSubmitting = false/);
+
+  const inputHandlerStart = html.indexOf('$("loginPin").addEventListener("input"');
+  const inputHandlerEnd = html.indexOf('$("loginGo").addEventListener("click"', inputHandlerStart);
+  const inputHandler = html.slice(inputHandlerStart, inputHandlerEnd);
+  assert.match(inputHandler, /replace\(\/\\D\/g, ""\)/);
+  assert.match(inputHandler, /normalized\.length === 4\) doLogin\(\)/);
+});
+
 test("PWA interpola valores fora do catálogo e não trata conteúdo dinâmico como HTML", () => {
   const literal = extractAssignedObject(html, "I18N");
   assert.ok(literal, "faltou o catálogo I18N para validar seus valores");

--- a/test/issue-19-i18n.test.mjs
+++ b/test/issue-19-i18n.test.mjs
@@ -1,0 +1,307 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const [html, obs, dockGrid, contentView, dokkeApp, docsMain, docsStyle, readme, readmeEn] = await Promise.all([
+  readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+  readFile(new URL("../obs.js", import.meta.url), "utf8"),
+  readFile(new URL("../mac/Sources/DockGridView.swift", import.meta.url), "utf8"),
+  readFile(new URL("../mac/Sources/ContentView.swift", import.meta.url), "utf8"),
+  readFile(new URL("../mac/Sources/DokkeApp.swift", import.meta.url), "utf8"),
+  readFile(new URL("../docs/src/main.js", import.meta.url), "utf8"),
+  readFile(new URL("../docs/src/style.css", import.meta.url), "utf8"),
+  readFile(new URL("../README.md", import.meta.url), "utf8"),
+  readFile(new URL("../README.en.md", import.meta.url), "utf8").catch(() => ""),
+]);
+
+const REQUIRED_I18N_KEYS = [
+  "login.title",
+  "login.description",
+  "login.pinLabel",
+  "login.connect",
+  "dock.apps",
+  "dock.openApps",
+  "dock.pinned",
+  "recents.title",
+  "recents.empty",
+  "modal.pinTitle",
+  "modal.cancel",
+  "modal.removeConfirm",
+  "toast.macDisconnected",
+  "toast.pinFailed",
+  "obs.title",
+  "obs.startRecording",
+  "obs.stopRecording",
+  "obs.stopAll",
+  "update.available",
+  "update.reload",
+  "aria.close",
+  "aria.language",
+  "aria.selectLanguage",
+];
+
+function extractBalancedObject(source, start) {
+  const open = source.indexOf("{", start);
+  if (open === -1) return null;
+
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = open; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, index + 1);
+    }
+  }
+
+  return null;
+}
+
+function extractAssignedObject(source, name) {
+  const assignment = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=`).exec(source);
+  return assignment ? extractBalancedObject(source, assignment.index) : null;
+}
+
+function extractFunction(source, name) {
+  const declaration = new RegExp(`function\\s+${name}\\s*\\(`).exec(source);
+  if (!declaration) return null;
+
+  const parametersOpen = source.indexOf("(", declaration.index);
+  let parametersDepth = 0;
+  let quote = null;
+  let escaped = false;
+  let bodyStart = -1;
+  for (let index = parametersOpen; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "\"" || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") parametersDepth += 1;
+    if (char === ")") {
+      parametersDepth -= 1;
+      if (parametersDepth === 0) {
+        bodyStart = index + 1;
+        break;
+      }
+    }
+  }
+  if (bodyStart === -1) return null;
+  const body = extractBalancedObject(source, bodyStart);
+  return body ? source.slice(declaration.index, bodyStart) + body : null;
+}
+
+function countMatches(source, expression) {
+  return [...source.matchAll(expression)].length;
+}
+
+test("PWA declara catálogos pt-BR e en com as mesmas chaves funcionais", () => {
+  const literal = extractAssignedObject(html, "I18N");
+  assert.ok(literal, "faltou const I18N = { ... }");
+
+  let catalogs;
+  assert.doesNotThrow(() => {
+    catalogs = Function(`\"use strict\"; return (${literal});`)();
+  }, "I18N precisa ser um objeto JavaScript válido");
+
+  assert.deepEqual(Object.keys(catalogs).sort(), ["en", "pt-BR"]);
+  assert.deepEqual(
+    Object.keys(catalogs["pt-BR"]).sort(),
+    Object.keys(catalogs.en).sort(),
+    "pt-BR e en precisam manter paridade de chaves",
+  );
+
+  for (const key of REQUIRED_I18N_KEYS) {
+    assert.ok(key in catalogs["pt-BR"], `faltou a chave ${key} em pt-BR`);
+    assert.ok(key in catalogs.en, `faltou a chave ${key} em en`);
+    assert.equal(typeof catalogs["pt-BR"][key], "string", `${key} em pt-BR precisa ser string`);
+    assert.equal(typeof catalogs.en[key], "string", `${key} em en precisa ser string`);
+    assert.ok(catalogs["pt-BR"][key].trim(), `${key} em pt-BR não pode ser vazio`);
+    assert.ok(catalogs.en[key].trim(), `${key} em en não pode ser vazio`);
+  }
+  assert.notEqual(catalogs["pt-BR"]["login.title"], catalogs.en["login.title"]);
+});
+
+test("PWA detecta o idioma do dispositivo sem preferência manual", () => {
+  assert.doesNotMatch(html, /dokke_lang/);
+  assert.doesNotMatch(html, /data-language=/);
+
+  const detectLanguage = extractFunction(html, "detectLanguage");
+  const getInitialLanguage = extractFunction(html, "getInitialLanguage");
+
+  assert.ok(detectLanguage, "faltou function detectLanguage(language = navigator.language)");
+  assert.ok(getInitialLanguage, "faltou function getInitialLanguage()");
+  assert.match(detectLanguage, /function detectLanguage\(language = navigator\.language\)/);
+  assert.match(getInitialLanguage, /return detectLanguage\(browserLanguage\)/);
+  const detect = Function(`${detectLanguage}\nreturn detectLanguage;`)();
+  assert.equal(detect("pt-PT"), "pt-BR");
+  assert.equal(detect("en-US"), "en");
+  assert.equal(detect("fr-FR"), "en");
+  assert.equal(detect(null), "pt-BR");
+
+  const makeInitialLanguage = (browserLanguage) => Function(
+    "navigator",
+    `${detectLanguage}\n${getInitialLanguage}\nreturn getInitialLanguage;`,
+  )({ language: browserLanguage });
+
+  assert.equal(makeInitialLanguage("pt-BR")(), "pt-BR");
+  assert.equal(makeInitialLanguage("fr-FR")(), "en");
+  assert.equal(makeInitialLanguage(null)(), "pt-BR");
+
+  assert.doesNotMatch(html, /function setLanguage/);
+  assert.doesNotMatch(html, /localStorage\.(getItem|setItem)/);
+});
+
+test("PWA não expõe seletor manual de idioma", () => {
+  assert.doesNotMatch(html, /language-control/);
+  assert.doesNotMatch(html, /data-language-control/);
+});
+
+test("PWA interpola valores fora do catálogo e não trata conteúdo dinâmico como HTML", () => {
+  const literal = extractAssignedObject(html, "I18N");
+  assert.ok(literal, "faltou o catálogo I18N para validar seus valores");
+  const catalogs = Function(`\"use strict\"; return (${literal});`)();
+  const serialized = JSON.stringify(catalogs);
+  const translate = extractFunction(html, "t");
+
+  assert.ok(translate, "faltou function t(key, values = {})");
+  assert.match(translate, /function t\(key, values = \{\}\)/);
+  assert.match(translate, /Object\.entries\(values\)/);
+  assert.doesNotMatch(translate, /innerHTML/);
+  assert.doesNotMatch(serialized, /https?:\/\//i, "URLs devem continuar fora do catálogo");
+  assert.doesNotMatch(serialized, /<\s*\/?\s*[a-z][^>]*>/i, "HTML funcional deve continuar fora do catálogo");
+  assert.doesNotMatch(serialized, /\b\d{4}\b/, "PINs devem continuar fora do catálogo");
+  assert.doesNotMatch(serialized, /\b(?:Safari|Google Chrome|Spotify|Visual Studio Code)\b/i, "nomes de apps devem continuar fora do catálogo");
+
+  const translateText = Function(
+    "I18N",
+    "currentLanguage",
+    `${translate}\nreturn t;`,
+  )(catalogs, "pt-BR");
+  const malicious = '<img src=x onerror="alert(1)">';
+  const translated = translateText("toast.pinAdded", { name: malicious });
+  assert.equal(typeof translated, "string");
+  assert.match(translated, /<img src=x onerror=/, "o valor deve permanecer texto literal");
+  assert.doesNotMatch(translated, /&lt;img/, "t não deve converter o texto para HTML");
+});
+
+test("PWA não sombreia o tradutor ao montar cards", () => {
+  const buildTile = extractFunction(html, "buildTile");
+  assert.ok(buildTile, "faltou function buildTile(a, withIcon)");
+  assert.match(buildTile, /const tile = document\.createElement\("div"\)/);
+  assert.doesNotMatch(buildTile, /const t = document\.createElement\("div"\)/);
+  assert.match(buildTile, /t\("dock\.opened"\)/);
+});
+
+test("contrato de i18n preserva marcadores atuais do PWA, OBS e macOS", () => {
+  assert.match(html, /id="launchpad"/);
+  assert.match(html, /id="launchpadTrack"/);
+  assert.match(html, /id="dots"/);
+  assert.match(html, /addEventListener\("pointerdown"/);
+  assert.match(html, /document\.body\.classList\.contains\("swiping"\)/);
+  assert.match(html, /maxPinnedApps/);
+  assert.match(html, /PINNED_LIMIT_REACHED/);
+  assert.match(html, /pinnedLimitMessage/);
+  assert.match(html, /id="drawer"/);
+  assert.match(html, /id="obspanel"/);
+  assert.match(html, /function confirmStopAll\(\)/);
+  assert.match(html, /\/api\/obs\//);
+
+  assert.match(obs, /request\(type, args = \{\}\)/);
+  assert.match(obs, /handleMessage\(raw\)/);
+  assert.match(obs, /toggleRecord\(\)/);
+  assert.match(obs, /GetSceneList/);
+  assert.match(obs, /GetRecordStatus/);
+  assert.match(obs, /StartRecord/);
+  assert.match(obs, /StopRecord/);
+
+  assert.match(dockGrid, /let pageSize = 8/);
+  assert.match(dockGrid, /private let pageHeight: CGFloat = 288/);
+  assert.match(dockGrid, /private let carouselGap: CGFloat = 24/);
+  assert.match(dockGrid, /private let carouselPeekRatio: CGFloat = 0\.55/);
+  assert.match(dockGrid, /LazyHStack\(alignment: \.center, spacing: carouselGap\)/);
+  assert.match(contentView, /ForEach\(SidebarItem\.allCases, id: \\.self\)/);
+  assert.match(contentView, /DokkeTheme\.selection/);
+  assert.match(contentView, /ZStack\(alignment: \.topLeading\)/);
+  assert.match(contentView, /Image\(systemName: "sidebar\.left"\)/);
+});
+
+test("macOS possui LanguageStore persistente e Picker no Conectar", () => {
+  assert.match(dokkeApp, /LanguageStore\(/, "DokkeApp precisa criar o LanguageStore");
+  assert.match(dokkeApp, /environmentObject\(languageStore\)/, "LanguageStore precisa chegar às views");
+  assert.match(contentView, /LanguageStore/);
+  assert.match(contentView, /Picker\(/, "Conectar precisa expor o Picker");
+  return readFile(new URL("../mac/Sources/LanguageStore.swift", import.meta.url), "utf8")
+    .then((languageStore) => {
+      assert.match(languageStore, /enum DokkeLanguage: String, CaseIterable, Identifiable/);
+      assert.match(languageStore, /case portuguese = "pt-BR"/);
+      assert.match(languageStore, /case english = "en"/);
+      assert.match(languageStore, /return "Português"/);
+      assert.match(languageStore, /return "English"/);
+      assert.match(languageStore, /"aria\.language": "Idioma"/);
+      assert.match(languageStore, /"aria\.language": "Language"/);
+      assert.match(languageStore, /UserDefaults/);
+      assert.match(languageStore, /@Published (?:private\(set\) )?var selected/);
+    });
+});
+
+test("landing e README oferecem os dois idiomas", () => {
+  assert.match(docsMain, /const LANDING_LANGUAGE_KEY = "dokke_landing_lang"/);
+  assert.match(docsMain, /function detectLandingLanguage\(language = navigator\.language\)/);
+  assert.match(docsMain, /localStorage\.getItem\(LANDING_LANGUAGE_KEY\)/);
+  assert.match(docsMain, /data-language-toggle/);
+  assert.match(docsMain, /document\.documentElement\.lang = landingLanguage/);
+  assert.match(docsMain, /["']pt-BR["']/);
+  assert.match(docsMain, /["']en["']/);
+  assert.match(docsMain, /localStorage\.setItem\(LANDING_LANGUAGE_KEY, landingLanguage\)/);
+  assert.match(docsStyle, /@media \(max-width: 760px\)[\s\S]*\.nav-shell \{ grid-template-columns: auto auto;/);
+  assert.match(docsStyle, /\.nav-actions \.github-link \{ min-height: 34px; padding: 0 12px; \}/);
+  assert.doesNotMatch(docsStyle, /\.nav-actions \.github-link span \{ display: none; \}/);
+  assert.ok(readmeEn.length > 0, "README.en.md precisa existir");
+  assert.match(readme, /README\.en\.md/);
+  assert.match(readmeEn, /README\.md/);
+});

--- a/test/mac-app-slides-ui.test.mjs
+++ b/test/mac-app-slides-ui.test.mjs
@@ -71,11 +71,11 @@ test("sidebar replica a seleção discreta da referência", () => {
 
 test("reordenação fica explícita no modo Reorganizar apps", () => {
   assert.match(dockGrid, /@State private var isReordering = false/);
-  assert.match(dockGrid, /Reorganizar apps/);
-  assert.match(dockGrid, /Concluir/);
+  assert.match(dockGrid, /I18n\.text\(isReordering \? "grid\.reorder\.done" : "grid\.reorder"/);
+  assert.match(dockGrid, /"grid\.reorder\.done"/);
   assert.match(dockGrid, /if isReordering/);
   assert.match(dockGrid, /\.overlay\(alignment: \.bottom/);
-  assert.match(dockGrid, /Arraste para mover um ícone de posição\./);
+  assert.match(dockGrid, /I18n\.text\("grid\.drag"/);
 });
 
 test("carrossel preserva o centro e ganha o respiro superior da referência", () => {
@@ -262,10 +262,10 @@ test("hover do app mostra remoção direta sem alterar o modo de reorder", () =>
   assert.match(dockIcon, /private let hoverBlurRadius: CGFloat = 4/);
   assert.match(dockIcon, /\.blur\(radius: isHovered \? hoverBlurRadius : 0\)/);
   assert.match(iconCard, /RoundedRectangle\(cornerRadius: 28/);
-  assert.match(iconCard, /Text\("Remover"\)/);
+  assert.match(iconCard, /I18n\.text\("icon\.remove"/);
   assert.doesNotMatch(iconCard, /\.opacity\(isHovered \? 1 : 0\)/);
   assert.match(iconCard, /if isReordering && isHovered \{\s*ZStack[\s\S]*?\.allowsHitTesting\(false\)/);
-  assert.match(iconCard, /Text\("Mover"\)/);
+  assert.match(iconCard, /I18n\.text\("icon\.move"/);
   assert.match(iconCard, /arrow\.up\.left\.and\.arrow\.down\.right/);
   assert.match(
     iconCard,
@@ -284,8 +284,8 @@ test("hover do app mostra remoção direta sem alterar o modo de reorder", () =>
   assert.doesNotMatch(dockIconBody, /\.onHover \{/);
   assert.match(iconCard, /\.zIndex\(5\)/);
   assert.doesNotMatch(iconCard, /\.transition\(/);
-  assert.match(iconCard, /Text\("Remover"\)[\s\S]*?\.contentShape\(Rectangle\(\)\)[\s\S]*?\.buttonStyle\(\.plain\)/);
-  assert.match(iconCard, /Remover app fixado/);
+  assert.match(iconCard, /I18n\.text\("icon\.remove"[\s\S]*?\.contentShape\(Rectangle\(\)\)[\s\S]*?\.buttonStyle\(\.plain\)/);
+  assert.match(iconCard, /I18n\.text\(piece\.type == \.website \? "icon\.removeWebsite" : "icon\.removeApp"/);
 });
 
 test("tracker AppKit atualiza o hover sem interceptar o botão", () => {
@@ -330,7 +330,7 @@ test("@spec:AC-342 hover sobrevive a scroll e sweeps sem exit perdido", () => {
 test("label do hover ocupa explicitamente todo o card antes da área clicável", () => {
   assert.match(
     iconCard,
-    /\} label: \{\s*ZStack \{[\s\S]*?Text\("Remover"\)[\s\S]*?\}\s*\.frame\(width: iconCardSize, height: iconCardSize\)\s*\.contentShape\(Rectangle\(\)\)\s*\}/,
+    /\} label: \{\s*ZStack \{[\s\S]*?I18n\.text\("icon\.remove"[\s\S]*?\}\s*\.frame\(width: iconCardSize, height: iconCardSize\)\s*\.contentShape\(Rectangle\(\)\)\s*\}/,
   );
 });
 

--- a/test/mac-connection-ui.test.mjs
+++ b/test/mac-connection-ui.test.mjs
@@ -153,8 +153,8 @@ test("menu bar abre o Dokke, sincroniza dados e expõe atualização somente qua
   assert.doesNotMatch(app, /WindowGroup\("Dokke", id: "main"\)/);
   assert.match(menuBar, /@EnvironmentObject private var updater: DokkeUpdateManager/);
   assert.match(menuBar, /openWindow\(id: "main"\)/);
-  assert.match(menuBar, /Sincronizar agora/);
-  assert.match(menuBar, /Verificar atualizações/);
+  assert.match(menuBar, /I18n\.text\("menu\.sync"/);
+  assert.match(menuBar, /I18n\.text\("updates\.check"/);
 });
 
 test("menu bar mantém o topo neutro e exibe métricas úteis", () => {
@@ -162,24 +162,24 @@ test("menu bar mantém o topo neutro e exibe métricas úteis", () => {
   assert.doesNotMatch(intro, /Image\(systemName: "circle\.fill"\)/);
   assert.doesNotMatch(intro, /Text\("Dokke"\)/);
   assert.doesNotMatch(menuBar, /Dokke online|Dokke offline/);
-  assert.ok(menuBar.includes('Text("Dispositivo: \\(store.devices)")'));
-  assert.ok(menuBar.includes('Text("Fixados: \\(store.pinned.count)")'));
+  assert.match(menuBar, /I18n\.text\("menu\.device"/);
+  assert.match(menuBar, /I18n\.text\("menu\.pinned"/);
   assert.doesNotMatch(menuBar, /Dispositivos conectados|Slots fixados/);
   assert.match(menuBar, /\.font\(\.caption\)/);
   assert.match(menuBar, /\.foregroundStyle\(\.secondary\)/);
 });
 
 test("menu bar usa ícones nos comandos e mostra a versão no rodapé", () => {
-  assert.match(menuBar, /Label\("Abrir Dokke", systemImage: "macwindow"\)/);
-  assert.match(menuBar, /Label\("Sincronizar agora", systemImage: "arrow\.triangle\.2\.circlepath"\)/);
-  assert.match(menuBar, /Label\("Verificar atualizações", systemImage: "arrow\.down\.circle"\)/);
-  assert.match(menuBar, /Label\("Baixar e instalar", systemImage: "arrow\.down\.circle"\)/);
-  assert.match(menuBar, /Label\("Sair", systemImage: "power"\)/);
+  assert.match(menuBar, /I18n\.text\("menu\.open"/);
+  assert.match(menuBar, /I18n\.text\("menu\.sync"/);
+  assert.match(menuBar, /I18n\.text\("updates\.check"/);
+  assert.match(menuBar, /I18n\.text\("updates\.install"/);
+  assert.match(menuBar, /I18n\.text\("menu\.quit"/);
   assert.match(menuBar, /CFBundleShortVersionString/);
   const footer = menuBar.slice(menuBar.lastIndexOf("      Divider()"));
   assert.match(footer, /Button\s*\{\s*\}\s*label: \{/);
   assert.match(footer, /HStack\(alignment: \.center, spacing: 0\)/);
-  assert.ok(footer.includes('Text("Versão \\(appVersion)")'));
+  assert.match(footer, /I18n\.text\("menu\.version"/);
   assert.match(footer, /fixedSize\(horizontal: true, vertical: false\)/);
   assert.match(footer, /Spacer\(minLength: 12\)[\s\S]*Text\("Dokke"\)/);
   assert.match(footer, /\.frame\(width: 250, alignment: \.leading\)/);

--- a/test/mac-picker-loading.test.mjs
+++ b/test/mac-picker-loading.test.mjs
@@ -17,6 +17,6 @@ test("inventário de apps repete o carregamento até o servidor responder", () =
 });
 
 test("picker não confunde carregamento inicial com inventário vazio", () => {
-  assert.match(picker, /ProgressView\("Carregando apps…"\)/);
+  assert.match(picker, /ProgressView\(I18n\.text\("picker\.loading", language: languageStore\.selected\)\)/);
   assert.match(picker, /store\.installedLoading && !store\.installedReady/);
 });

--- a/test/ui.test.mjs
+++ b/test/ui.test.mjs
@@ -20,7 +20,7 @@ test("GET / serve as 2 telas (apps + apps abertos) liquid glass", async () => {
       /\.login-card\{[\s\S]*background: linear-gradient\(165deg, rgba\(255,255,255,\.18\), rgba\(255,255,255,\.07\) 55%, rgba\(255,255,255,\.12\)\);/,
       "painel de conexão deve ter opacidade suficiente para preservar a leitura"
     );
-    assert.match(html, /toast\("Dispositivo conectado"\)/, "o status deve identificar o dispositivo conectado");
+    assert.match(html, /toast\(t\("toast\.deviceConnected"\)\)/, "o status deve identificar o dispositivo conectado");
     assert.doesNotMatch(html, /toast\("Mac conectado"\)/, "o status não deve atribuir a conexão ao Mac");
     assert.match(html, /id="vdots"/, "html deve ter os dots verticais laterais");
     assert.match(html, /\.vdots\{[\s\S]*safe-area-inset-right/, "V-Dots devem respeitar a safe area lateral");

--- a/test/website-pieces-ui.test.mjs
+++ b/test/website-pieces-ui.test.mjs
@@ -21,14 +21,14 @@ test("@spec:AC-311 companion abre site somente por ID remoto e permanece no Dokk
   assert.match(action, /\/api\/pieces\/" \+ encodeURIComponent\(piece\.id\) \+ "\/open/);
   assert.doesNotMatch(action, /window\.open|location\.(assign|replace)|href/);
   const tile = pwa.slice(pwa.indexOf("function buildTile"), pwa.indexOf("function replaceChildren"));
-  assert.match(tile, /t\.dataset\.id = a\.id/);
-  assert.match(tile, /t\.dataset\.type = a\.type/);
+  assert.match(tile, /tile\.dataset\.id = a\.id/);
+  assert.match(tile, /tile\.dataset\.type = a\.type/);
   assert.doesNotMatch(tile, /<a|href/);
 });
 
 test("@spec:AC-320 picker mantém Apps e adiciona exatamente Website Links", () => {
-  assert.match(picker, /Text\("Apps"\)\.tag\("Apps"\)/);
-  assert.match(picker, /Text\("Website Links"\)\.tag\("Website Links"\)/);
+  assert.match(picker, /I18n\.text\("picker\.apps"/);
+  assert.match(picker, /I18n\.text\("picker\.websites"/);
   assert.match(picker, /pickerStyle\(\.segmented\)/);
   assert.match(picker, /labelsHidden\(\)/);
   assert.match(picker, /frame\(maxWidth: \.infinity\)/);
@@ -45,19 +45,19 @@ test("@spec:AC-320 picker mantém Apps e adiciona exatamente Website Links", () 
   assert.match(picker, /websiteIconPlate\(rawURL: suggestion\.1\)/);
   assert.match(picker, /WebsiteFaviconView\(rawURL: rawURL/);
   assert.match(picker, /LazyVStack\(spacing: 0\)/);
-  assert.match(picker, /Button\("Adicionar"\)/);
+  assert.match(picker, /Button\(I18n\.text\("picker\.add"/);
   assert.doesNotMatch(picker, /Apple Shortcuts/);
 });
 
 test("picker Apps usa a mesma linguagem de cards e ações azuis", () => {
-  assert.match(picker, /Text\("App Library"\)/);
+  assert.match(picker, /I18n\.text\("picker\.library"/);
   assert.match(picker, /private func appRow\(_ app: InstalledApp\)/);
   assert.match(picker, /frame\(maxWidth: \.infinity, minHeight: 50\)/);
   assert.match(picker, /DokkeTheme\.page\.opacity\(0\.68\)/);
   assert.match(picker, /\.buttonStyle\(\.borderedProminent\)/);
   const appRow = picker.slice(picker.indexOf("private func appRow"));
   assert.match(appRow, /Image\(systemName: "checkmark\.circle\.fill"\)/);
-  assert.match(appRow, /accessibilityLabel\("Adicionado"\)/);
+  assert.match(appRow, /accessibilityLabel\(I18n\.text\("picker\.added"/);
   assert.doesNotMatch(appRow, /Label\("Adicionado", systemImage:/);
   assert.match(appRow, /\.frame\(width: 34, height: 34\)/);
   assert.match(appRow, /\.buttonStyle\(\.borderedProminent\)/);
@@ -77,7 +77,7 @@ test("Website Links pede o nome somente depois de iniciar a adição", () => {
   assert.match(picker, /@State private var showWebsiteNamePrompt = false/);
   assert.match(picker, /beginWebsiteAdd\(url: websiteURL\)/);
   assert.match(picker, /beginWebsiteAdd\(url: suggestion\.1, suggestedTitle: suggestion\.0\)/);
-  assert.match(picker, /Text\("Vamos dar um nome curto para o seu weblink\."\)/);
+  assert.match(picker, /I18n\.text\("picker\.nameHint"/);
   assert.doesNotMatch(picker, /Let's give it a catchy and short name/);
   assert.match(picker, /confirmWebsiteAdd\(\)/);
   assert.doesNotMatch(picker, /TextField\("Título \(opcional\)"/);


### PR DESCRIPTION
## Resumo

Implementa a issue #19 com suporte consistente a Português (Brasil) e English nas superfícies do Dokke, preservando os contratos visuais e funcionais atuais.

## O que foi alterado

- Adiciona catálogos `pt-BR` e `en` ao PWA/APK, com detecção automática pelo idioma do dispositivo.
- Mantém o PWA/APK sem seletor manual; o APK reutiliza a mesma interface web.
- Adiciona `LanguageStore` persistente e seletor de idioma na tela Conectar do app macOS.
- Adiciona seletor PT/EN persistente na landing page e tradução completa da cópia.
- Adiciona `README.en.md` com instruções equivalentes.
- Traduz estados dinâmicos, erros, confirmações, toasts, OBS, atualização e acessibilidade.
- Corrige o sombreamento de `t` em `buildTile`, que fazia o APK carregar sem exibir apps.
- Faz o login enviar o PIN automaticamente no quarto dígito, inclusive ao colar o código, com proteção contra requisições duplicadas.
- Preserva grid, paginação, gestos, safe area, sidebar, canvas, protocolo e comportamento de websites.

## Relação com a PR comunitária

A PR #20 foi analisada apenas como fonte de insights. Nenhum arquivo foi substituído integralmente e a PR não foi aprovada.

## Validação

- 74/74 testes focados de i18n e contratos legados passaram.
- `swift build` passou.
- `npm run build` em `docs/` passou.
- Sintaxe JavaScript do PWA validada.
- `git diff --check` passou.
- Host macOS recompilado, reinstalado e validado em `/health` e no HTML servido pelo PWA.
- Landing publicada e validada na Vercel durante a implementação.

## Limitações

- Os testes visuais Playwright não foram executados porque o Chromium local não está instalado.
- Nenhum merge em `develop` é feito por esta PR automaticamente.

Closes #19